### PR TITLE
udp: add support for bind, connect and try_send

### DIFF
--- a/test/helpers.h
+++ b/test/helpers.h
@@ -23,6 +23,9 @@ constexpr int kTestPort = 9123;
 #define container_of(ptr, type, member)                                       \
   reinterpret_cast<type*>(reinterpret_cast<char*>(ptr) - offsetof(type, member))
 
+#define SOCKADDR_CAST(addr) \
+  reinterpret_cast<struct sockaddr*>(addr)
+
 static void close_walk_cb(uv_handle_t* handle, void*) {
   if (!uv_is_closing(handle))
     uv_close(handle, nullptr);

--- a/test/test-udp.cc
+++ b/test/test-udp.cc
@@ -1,0 +1,81 @@
+#include "../include/nsuv-inl.h"
+#include "./catch.hpp"
+#include "./helpers.h"
+
+#define TEST_PORT 35123
+
+using nsuv::ns_udp;
+using nsuv::ns_udp_send;
+
+ns_udp client;
+ns_udp server;
+static int cl_send_cb_called;
+static const char* exit_str = "EXIT";
+
+static void cl_send_cb(ns_udp_send* req, int status) {
+  REQUIRE(req != nullptr);
+  REQUIRE(status == 0);
+  REQUIRE(req->handle() == &client);
+  ++cl_send_cb_called;
+  client.close(nullptr);
+  server.close(nullptr);
+}
+
+TEST_CASE("udp", "[udp-connect]") {
+  ns_udp_send req;
+  uv_buf_t buf;
+  struct sockaddr_in ext_addr;
+  struct sockaddr_in lo_addr;
+
+  REQUIRE(0 == server.init(uv_default_loop()));
+
+  REQUIRE(0 == client.init(uv_default_loop()));
+
+  buf = uv_buf_init(const_cast<char*>(exit_str), 4);
+
+  REQUIRE(0 == uv_ip4_addr("8.8.8.8", TEST_PORT, &ext_addr));
+  REQUIRE(0 == uv_ip4_addr("127.0.0.1", TEST_PORT, &lo_addr));
+
+  REQUIRE(nullptr == server.local_addr());
+  REQUIRE(nullptr == server.remote_addr());
+  REQUIRE(0 == server.bind(SOCKADDR_CAST(&lo_addr), 0));
+  REQUIRE(0 == memcmp(&lo_addr, server.local_addr(), sizeof(lo_addr)));
+  REQUIRE(nullptr == server.remote_addr());
+
+  REQUIRE(nullptr == client.local_addr());
+  REQUIRE(nullptr == client.remote_addr());
+  REQUIRE(0 == client.connect(SOCKADDR_CAST(&lo_addr)));
+  REQUIRE(UV_EISCONN == client.connect(SOCKADDR_CAST(&ext_addr)));
+  REQUIRE(nullptr != client.local_addr());
+  REQUIRE(0 == memcmp(&lo_addr, client.remote_addr(), sizeof(lo_addr)));
+
+  /* To send messages in connected UDP sockets addr must be NULL */
+  REQUIRE(UV_EISCONN == client.try_send(&buf, 1, SOCKADDR_CAST(&lo_addr)));
+  REQUIRE(4 == client.try_send(&buf, 1, nullptr));
+  REQUIRE(UV_EISCONN == client.try_send(&buf, 1, SOCKADDR_CAST(&ext_addr)));
+
+  REQUIRE(0 == client.connect(nullptr));
+  REQUIRE(UV_ENOTCONN == client.connect(nullptr));
+  REQUIRE(nullptr != client.local_addr());
+  REQUIRE(nullptr == client.remote_addr());
+
+  /* To send messages in disconnected UDP sockets addr must be set */
+  REQUIRE(4 == client.try_send(&buf, 1, SOCKADDR_CAST(&lo_addr)));
+  REQUIRE(UV_EDESTADDRREQ == client.try_send(&buf, 1, nullptr));
+
+  REQUIRE(0 == client.connect(SOCKADDR_CAST(&lo_addr)));
+  REQUIRE(nullptr != client.local_addr());
+  REQUIRE(0 == memcmp(&lo_addr, client.remote_addr(), sizeof(lo_addr)));
+
+  REQUIRE(UV_EISCONN ==
+          client.send(&req, &buf, 1, SOCKADDR_CAST(&lo_addr), cl_send_cb));
+  REQUIRE(0 == client.send(&req, &buf, 1, nullptr, cl_send_cb));
+
+  REQUIRE(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+
+  REQUIRE(cl_send_cb_called == 1);
+
+  REQUIRE(client.uv_handle()->send_queue_size == 0);
+
+  make_valgrind_happy();
+}


### PR DESCRIPTION
Also, add methods to retrieve the local address and the remote address of
a `ns_udp` handle.
Finally, use `struct sockaddr_storage` instead of `struct sockaddr` to
store addresses to make sure any kind sockaddr_ variant can be correctly
kept.