### PR TITLE
src: fix gcc compilation error

### DIFF
--- a/include/nsuv-inl.h
+++ b/include/nsuv-inl.h
@@ -474,7 +474,7 @@ void ns_handle<UV_T, H_T>::close_delete_cb_(uv_handle_t* handle) {
 
 template <class UV_T, class H_T>
 uv_stream_t* ns_stream<UV_T, H_T>::base_stream() {
-  return reinterpret_cast<uv_stream_t*>(H_T::uv_handle());
+  return reinterpret_cast<uv_stream_t*>(this->uv_handle());
 }
 
 template <class UV_T, class H_T>


### PR DESCRIPTION
It fixes the following compilation error, at least in `gcc 7.5.0`:
```
error: cannot call member function ‘UV_T* nsuv::ns_handle<
<template-parameter-1-1>, <template-parameter-1-2> >::uv_handle()
[with UV_T = uv_tcp_s; H_T = nsuv::ns_tcp]’ without object
```