### PR TITLE
mutex: allow auto destroy mutex

### DIFF
--- a/include/nsuv.h
+++ b/include/nsuv.h
@@ -526,12 +526,23 @@ class ns_udp : public ns_handle<uv_udp_t, ns_udp> {
 
 class ns_mutex {
  public:
-  NSUV_INLINE NSUV_WUR int init();
-  NSUV_INLINE NSUV_WUR int init_recursive();
+  // Constructor for allowing auto init() and destroy().
+  NSUV_INLINE explicit ns_mutex(int* er, bool recursive = false);
+  ns_mutex() = default;
+  NSUV_INLINE ~ns_mutex();
+
+  // Leaving the manual init() available in case the user decides to use the
+  // default constructor. For cases where default constructor must be used,
+  // such as being placed as a class member, pass true to init() to enable auto
+  // destroy().
+  NSUV_INLINE NSUV_WUR int init(bool ad = false);
+  NSUV_INLINE NSUV_WUR int init_recursive(bool ad = false);
   NSUV_INLINE void destroy();
   NSUV_INLINE void lock();
   NSUV_INLINE NSUV_WUR int trylock();
   NSUV_INLINE void unlock();
+  // Return if destroy() has been called on the mutex.
+  NSUV_INLINE bool destroyed();
 
   class scoped_lock {
    public:
@@ -548,6 +559,8 @@ class ns_mutex {
 
  private:
   uv_mutex_t mutex_;
+  bool auto_destruct_ = false;
+  bool destroyed_ = false;
 };
 
 

--- a/test/test-mutexes.cc
+++ b/test/test-mutexes.cc
@@ -16,6 +16,66 @@ TEST_CASE("thread_mutex", "[mutex]") {
   REQUIRE(mutex.trylock() == 0);
   mutex.unlock();
   mutex.destroy();
+  REQUIRE(mutex.destroyed());
+}
+
+TEST_CASE("thread_mutex_init", "[mutex]") {
+  ns_mutex mutex;
+  int r;
+
+  r = mutex.init(true);
+  REQUIRE(r == 0);
+
+  mutex.lock();
+  REQUIRE(mutex.trylock() == UV_EBUSY);
+  mutex.unlock();
+  REQUIRE(mutex.trylock() == 0);
+  mutex.unlock();
+}
+
+
+TEST_CASE("thread_mutex_auto", "[mutex]") {
+  int r;
+  ns_mutex mutex(&r);
+  REQUIRE(r == 0);
+
+  mutex.lock();
+  REQUIRE(mutex.trylock() == UV_EBUSY);
+  mutex.unlock();
+  REQUIRE(mutex.trylock() == 0);
+  mutex.unlock();
+}
+
+
+TEST_CASE("thread_mutex_scoped", "[mutex]") {
+  ns_mutex mutex;
+  int r;
+
+  r = mutex.init();
+  REQUIRE(r == 0);
+
+  {
+    ns_mutex::scoped_lock lock(&mutex);
+    REQUIRE(mutex.trylock() == UV_EBUSY);
+    mutex.unlock();
+    REQUIRE(mutex.trylock() == 0);
+  }
+  mutex.destroy();
+  REQUIRE(mutex.destroyed());
+}
+
+
+TEST_CASE("thread_mutex_auto_scoped", "[mutex]") {
+  int r;
+  ns_mutex mutex(&r);
+  REQUIRE(r == 0);
+
+  {
+    ns_mutex::scoped_lock lock(&mutex);
+    REQUIRE(mutex.trylock() == UV_EBUSY);
+    mutex.unlock();
+    REQUIRE(mutex.trylock() == 0);
+  }
 }
 
 
@@ -34,4 +94,57 @@ TEST_CASE("thread_mutex_recursive", "[mutex]") {
   mutex.unlock();
   mutex.unlock();
   mutex.destroy();
+  REQUIRE(mutex.destroyed());
+}
+
+
+TEST_CASE("thread_mutex_recursive_auto", "[mutex]") {
+  int r;
+  ns_mutex mutex(&r, true);
+  REQUIRE(r == 0);
+
+  mutex.lock();
+  mutex.lock();
+  REQUIRE(mutex.trylock() == 0);
+
+  mutex.unlock();
+  mutex.unlock();
+  mutex.unlock();
+}
+
+
+TEST_CASE("thread_mutex_recursive_scoped", "[mutex]") {
+  ns_mutex mutex;
+  int r;
+
+  r = mutex.init_recursive();
+  REQUIRE(r == 0);
+
+  {
+    ns_mutex::scoped_lock lock1(&mutex);
+    {
+      ns_mutex::scoped_lock lock2(&mutex);
+      REQUIRE(mutex.trylock() == 0);
+      mutex.unlock();
+    }
+  }
+
+  mutex.destroy();
+  REQUIRE(mutex.destroyed());
+}
+
+
+TEST_CASE("thread_mutex_recursive_auto_scoped", "[mutex]") {
+  int r;
+  ns_mutex mutex(&r, true);
+  REQUIRE(r == 0);
+
+  {
+    ns_mutex::scoped_lock lock1(&mutex);
+    {
+      ns_mutex::scoped_lock lock2(&mutex);
+      REQUIRE(mutex.trylock() == 0);
+      mutex.unlock();
+    }
+  }
 }


### PR DESCRIPTION
Allow ns_mutex to call destroy() from the destructor if the non-default
constructor was used.