### PR TITLE
util: fix addr_size for unix domain sockets

### DIFF
--- a/include/nsuv-inl.h
+++ b/include/nsuv-inl.h
@@ -1469,7 +1469,7 @@ int util::addr_size(const struct sockaddr* addr) {
     len = sizeof(struct sockaddr_in);
   } else if (addr->sa_family == AF_INET6) {
     len = sizeof(struct sockaddr_in6);
-  } else if (addr->sa_family == SOCK_STREAM) {
+  } else if (addr->sa_family == AF_UNIX) {
     len = sizeof(struct sockaddr_un);
   } else {
     return UV_EINVAL;


### PR DESCRIPTION
Previously sa_family was checked against SOCK_STREAM instead of AF_UNIX. This just happened to work out because in socket.h they are defined like this:

    #define SOCK_STREAM   1
    #define AF_UNIX       1

Fix it so sa_family is instead checked against the address family and not the socket type.