### PR TITLE
threadpool: add support for ns_work

### DIFF
--- a/include/nsuv.h
+++ b/include/nsuv.h
@@ -53,6 +53,7 @@ class ns_tcp;
 class ns_timer;
 class ns_prepare;
 class ns_udp;
+class ns_work;
 
 /* everything else */
 class ns_mutex;
@@ -228,6 +229,36 @@ class ns_addrinfo : public ns_base_req<uv_getaddrinfo_t, ns_addrinfo> {
 
   void (*addrinfo_cb_ptr_)() = nullptr;
   void* addrinfo_cb_data_ = nullptr;
+};
+
+
+/* ns_work */
+
+class ns_work : public ns_base_req<uv_work_t, ns_work> {
+ public:
+  NSUV_INLINE NSUV_WUR int queue_work(uv_loop_t* loop,
+                                      void (*work_cb)(ns_work*),
+                                      void (*after_cb)(ns_work*, int));
+  template <typename D_T>
+  NSUV_INLINE NSUV_WUR int queue_work(uv_loop_t* loop,
+                                      void (*work_cb)(ns_work*, D_T*),
+                                      void (*after_cb)(ns_work*, int, D_T*),
+                                      D_T* data);
+  // libuv allows passing nullptr as after_cb, so create another overload.
+  NSUV_INLINE NSUV_WUR int queue_work(uv_loop_t* loop,
+                                      void (*work_cb)(ns_work*));
+  template <typename D_T>
+  NSUV_INLINE NSUV_WUR int queue_work(uv_loop_t* loop,
+                                      void (*work_cb)(ns_work*, D_T*),
+                                      D_T* data);
+
+ private:
+  NSUV_PROXY_FNS(work_proxy_, uv_work_t*);
+  NSUV_PROXY_FNS(after_proxy_, uv_work_t*, int);
+
+  void (*work_cb_ptr_)() = nullptr;
+  void (*after_cb_ptr_)() = nullptr;
+  void* cb_data_ = nullptr;
 };
 
 

--- a/test/test-threadpool-cancel.cc
+++ b/test/test-threadpool-cancel.cc
@@ -1,0 +1,342 @@
+#include "../include/nsuv-inl.h"
+#include "./catch.hpp"
+#include "./helpers.h"
+
+using nsuv::ns_addrinfo;
+using nsuv::ns_timer;
+using nsuv::ns_work;
+
+#define INIT_CANCEL_INFO(ci, what)                                            \
+  do {                                                                        \
+    (ci)->reqs = (what);                                                      \
+    (ci)->nreqs = ARRAY_SIZE(what);                                           \
+    (ci)->stride = sizeof((what)[0]);                                         \
+  }                                                                           \
+  while (0)
+
+struct cancel_info {
+  void* reqs;
+  unsigned nreqs;
+  unsigned stride;
+  ns_timer timer_handle;
+};
+
+struct random_info {
+  uv_random_t random_req;
+  char buf[1];
+};
+
+static unsigned fs_cb_called;
+static unsigned done_cb_called;
+static unsigned done2_cb_called;
+static unsigned timer_cb_called;
+static ns_work pause_reqs[4];
+static uv_sem_t pause_sems[ARRAY_SIZE(pause_reqs)];
+
+
+static void work_cb(ns_work* req) {
+  uv_sem_wait(pause_sems + (req - pause_reqs));
+}
+
+
+static void done_cb(ns_work* req, int) {
+  uv_sem_destroy(pause_sems + (req - pause_reqs));
+}
+
+
+static void saturate_threadpool(void) {
+  uv_loop_t* loop;
+  char buf[64];
+  size_t i;
+
+  snprintf(buf,
+           sizeof(buf),
+           "UV_THREADPOOL_SIZE=%lu",
+           static_cast<uint64_t>(ARRAY_SIZE(pause_reqs)));
+  putenv(buf);
+
+  loop = uv_default_loop();
+  for (i = 0; i < ARRAY_SIZE(pause_reqs); i += 1) {
+    ASSERT(0 == uv_sem_init(pause_sems + i, 0));
+    ASSERT(0 == pause_reqs[i].queue_work(loop, work_cb, done_cb));
+  }
+}
+
+
+static void unblock_threadpool() {
+  size_t i;
+
+  for (i = 0; i < ARRAY_SIZE(pause_reqs); i += 1)
+    uv_sem_post(pause_sems + i);
+}
+
+
+static void fs_cb(uv_fs_t* req) {
+  ASSERT(req->result == UV_ECANCELED);
+  uv_fs_req_cleanup(req);
+  fs_cb_called++;
+}
+
+
+static void getaddrinfo_cb(ns_addrinfo*,
+                           int status,
+                           struct addrinfo* res) {
+  ASSERT(status == UV_EAI_CANCELED);
+  ASSERT_NULL(res);
+}
+
+
+static void getnameinfo_cb(uv_getnameinfo_t*,
+                           int status,
+                           const char* hostname,
+                           const char* service) {
+  ASSERT(status == UV_EAI_CANCELED);
+  ASSERT_NULL(hostname);
+  ASSERT_NULL(service);
+}
+
+
+static void work2_cb(ns_work*) {
+  FAIL("work2_cb called");
+}
+
+
+static void done2_cb(ns_work*, int status) {
+  ASSERT(status == UV_ECANCELED);
+  done2_cb_called++;
+}
+
+
+static void timer_cb(ns_timer*, struct cancel_info* ci) {
+  uv_req_t* req;
+  unsigned i;
+
+  for (i = 0; i < ci->nreqs; i++) {
+    req = reinterpret_cast<uv_req_t*>(
+      reinterpret_cast<char*>(ci->reqs) + i * ci->stride);
+    ASSERT(0 == uv_cancel(req));
+  }
+
+  ci->timer_handle.close();
+  unblock_threadpool();
+  timer_cb_called++;
+}
+
+
+static void nop_done_cb(ns_work*, int status) {
+  ASSERT(status == UV_ECANCELED);
+  done_cb_called++;
+}
+
+
+static void nop_random_cb(uv_random_t* req, int status, void* buf, size_t len) {
+  struct random_info* ri;
+
+  ri = container_of(req, struct random_info, random_req);
+
+  ASSERT(status == UV_ECANCELED);
+  ASSERT(buf == ri->buf);
+  ASSERT(len == sizeof(ri->buf));
+
+  done_cb_called++;
+}
+
+
+TEST_CASE("threadpool_cancel_getaddrinfo", "[threadpool]") {
+  ns_addrinfo reqs[4];
+  struct cancel_info ci;
+  struct addrinfo hints;
+  uv_loop_t* loop;
+  int r;
+
+  timer_cb_called = 0;
+
+  INIT_CANCEL_INFO(&ci, reqs);
+  loop = uv_default_loop();
+  saturate_threadpool();
+
+  r = reqs[0].get(loop, getaddrinfo_cb, "fail", nullptr, nullptr);
+  ASSERT(r == 0);
+
+  r = reqs[1].get(loop, getaddrinfo_cb, nullptr, "fail", nullptr);
+  ASSERT(r == 0);
+
+  r = reqs[2].get(loop, getaddrinfo_cb, "fail", "fail", nullptr);
+  ASSERT(r == 0);
+
+  r = reqs[3].get(loop, getaddrinfo_cb, "fail", nullptr, &hints);
+  ASSERT(r == 0);
+
+  ASSERT(0 == ci.timer_handle.init(loop));
+  ASSERT(0 == ci.timer_handle.start(timer_cb, 10, 0, &ci));
+  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT(1 == timer_cb_called);
+
+  make_valgrind_happy();
+}
+
+
+TEST_CASE("threadpool_cancel_getnameinfo", "[threadpool]") {
+  uv_getnameinfo_t reqs[4];
+  struct sockaddr_in addr4;
+  struct cancel_info ci;
+  uv_loop_t* loop;
+  int r;
+
+  timer_cb_called = 0;
+
+  r = uv_ip4_addr("127.0.0.1", 80, &addr4);
+  ASSERT(r == 0);
+
+  INIT_CANCEL_INFO(&ci, reqs);
+  loop = uv_default_loop();
+  saturate_threadpool();
+
+  r = uv_getnameinfo(
+      loop, reqs + 0, getnameinfo_cb, SOCKADDR_CONST_CAST(&addr4), 0);
+  ASSERT(r == 0);
+
+  r = uv_getnameinfo(
+      loop, reqs + 1, getnameinfo_cb, SOCKADDR_CONST_CAST(&addr4), 0);
+  ASSERT(r == 0);
+
+  r = uv_getnameinfo(
+      loop, reqs + 2, getnameinfo_cb, SOCKADDR_CONST_CAST(&addr4), 0);
+  ASSERT(r == 0);
+
+  r = uv_getnameinfo(
+      loop, reqs + 3, getnameinfo_cb, SOCKADDR_CONST_CAST(&addr4), 0);
+  ASSERT(r == 0);
+
+  ASSERT(0 == ci.timer_handle.init(loop));
+  ASSERT(0 == ci.timer_handle.start(timer_cb, 10, 0, &ci));
+  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT(1 == timer_cb_called);
+
+  make_valgrind_happy();
+}
+
+
+TEST_CASE("threadpool_cancel_random", "[threadpool]") {
+  struct random_info req;
+  uv_loop_t* loop;
+
+  done_cb_called = 0;
+
+  saturate_threadpool();
+  loop = uv_default_loop();
+  ASSERT(0 == uv_random(loop,
+                        &req.random_req,
+                        &req.buf,
+                        sizeof(req.buf),
+                        0,
+                        nop_random_cb));
+  ASSERT(0 == uv_cancel(reinterpret_cast<uv_req_t*>(&req)));
+  ASSERT(0 == done_cb_called);
+  unblock_threadpool();
+  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT(1 == done_cb_called);
+
+  make_valgrind_happy();
+}
+
+
+TEST_CASE("threadpool_cancel_work", "[threadpool]") {
+  struct cancel_info ci;
+  ns_work reqs[16];
+  uv_loop_t* loop;
+  unsigned i;
+
+  timer_cb_called = 0;
+  done2_cb_called = 0;
+
+  INIT_CANCEL_INFO(&ci, reqs);
+  loop = uv_default_loop();
+  saturate_threadpool();
+
+  for (i = 0; i < ARRAY_SIZE(reqs); i++)
+    ASSERT(0 == reqs[i].queue_work(loop, work2_cb, done2_cb));
+
+  ASSERT(0 == ci.timer_handle.init(loop));
+  ASSERT(0 == ci.timer_handle.start(timer_cb, 10, 0, &ci));
+  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT(1 == timer_cb_called);
+  ASSERT(ARRAY_SIZE(reqs) == done2_cb_called);
+
+  make_valgrind_happy();
+}
+
+
+TEST_CASE("threadpool_cancel_fs", "[threadpool]") {
+  struct cancel_info ci;
+  uv_fs_t reqs[26];
+  uv_loop_t* loop;
+  unsigned n;
+  uv_buf_t iov;
+
+  fs_cb_called = 0;
+  timer_cb_called = 0;
+
+  INIT_CANCEL_INFO(&ci, reqs);
+  loop = uv_default_loop();
+  saturate_threadpool();
+  iov = uv_buf_init(nullptr, 0);
+
+  /* Needs to match ARRAY_SIZE(fs_reqs). */
+  n = 0;
+  ASSERT(0 == uv_fs_chmod(loop, reqs + n++, "/", 0, fs_cb));
+  ASSERT(0 == uv_fs_chown(loop, reqs + n++, "/", 0, 0, fs_cb));
+  ASSERT(0 == uv_fs_close(loop, reqs + n++, 0, fs_cb));
+  ASSERT(0 == uv_fs_fchmod(loop, reqs + n++, 0, 0, fs_cb));
+  ASSERT(0 == uv_fs_fchown(loop, reqs + n++, 0, 0, 0, fs_cb));
+  ASSERT(0 == uv_fs_fdatasync(loop, reqs + n++, 0, fs_cb));
+  ASSERT(0 == uv_fs_fstat(loop, reqs + n++, 0, fs_cb));
+  ASSERT(0 == uv_fs_fsync(loop, reqs + n++, 0, fs_cb));
+  ASSERT(0 == uv_fs_ftruncate(loop, reqs + n++, 0, 0, fs_cb));
+  ASSERT(0 == uv_fs_futime(loop, reqs + n++, 0, 0, 0, fs_cb));
+  ASSERT(0 == uv_fs_link(loop, reqs + n++, "/", "/", fs_cb));
+  ASSERT(0 == uv_fs_lstat(loop, reqs + n++, "/", fs_cb));
+  ASSERT(0 == uv_fs_mkdir(loop, reqs + n++, "/", 0, fs_cb));
+  ASSERT(0 == uv_fs_open(loop, reqs + n++, "/", 0, 0, fs_cb));
+  ASSERT(0 == uv_fs_read(loop, reqs + n++, 0, &iov, 1, 0, fs_cb));
+  ASSERT(0 == uv_fs_scandir(loop, reqs + n++, "/", 0, fs_cb));
+  ASSERT(0 == uv_fs_readlink(loop, reqs + n++, "/", fs_cb));
+  ASSERT(0 == uv_fs_realpath(loop, reqs + n++, "/", fs_cb));
+  ASSERT(0 == uv_fs_rename(loop, reqs + n++, "/", "/", fs_cb));
+  ASSERT(0 == uv_fs_mkdir(loop, reqs + n++, "/", 0, fs_cb));
+  ASSERT(0 == uv_fs_sendfile(loop, reqs + n++, 0, 0, 0, 0, fs_cb));
+  ASSERT(0 == uv_fs_stat(loop, reqs + n++, "/", fs_cb));
+  ASSERT(0 == uv_fs_symlink(loop, reqs + n++, "/", "/", 0, fs_cb));
+  ASSERT(0 == uv_fs_unlink(loop, reqs + n++, "/", fs_cb));
+  ASSERT(0 == uv_fs_utime(loop, reqs + n++, "/", 0, 0, fs_cb));
+  ASSERT(0 == uv_fs_write(loop, reqs + n++, 0, &iov, 1, 0, fs_cb));
+  ASSERT(n == ARRAY_SIZE(reqs));
+
+  ASSERT(0 == ci.timer_handle.init(loop));
+  ASSERT(0 == ci.timer_handle.start(timer_cb, 10, 0, &ci));
+  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT(n == fs_cb_called);
+  ASSERT(1 == timer_cb_called);
+
+
+  make_valgrind_happy();
+}
+
+
+TEST_CASE("threadpool_cancel_single", "[threadpool]") {
+  uv_loop_t* loop;
+  ns_work req;
+
+  done_cb_called = 0;
+
+  saturate_threadpool();
+  loop = uv_default_loop();
+  ASSERT(0 == req.queue_work(loop, [](ns_work*) { abort(); }, nop_done_cb));
+  ASSERT(0 == req.cancel());
+  ASSERT(0 == done_cb_called);
+  unblock_threadpool();
+  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT(1 == done_cb_called);
+
+  make_valgrind_happy();
+}

--- a/test/test-threadpool.cc
+++ b/test/test-threadpool.cc
@@ -1,0 +1,140 @@
+#include "../include/nsuv-inl.h"
+#include "./catch.hpp"
+#include "./helpers.h"
+
+using nsuv::ns_work;
+
+static int work_cb_count;
+static int after_work_cb_count;
+static ns_work work_req;
+static char data;
+
+
+static void work_cb(ns_work* req, char* d) {
+  ASSERT(req == &work_req);
+  ASSERT(d == &data);
+  work_cb_count++;
+}
+
+static void work_cb(ns_work* req) {
+  ASSERT(req == &work_req);
+  work_cb_count++;
+}
+
+static void after_work_cb(ns_work* req, int status, char* d) {
+  ASSERT(status == 0);
+  ASSERT(req == &work_req);
+  ASSERT(d == &data);
+  after_work_cb_count++;
+}
+
+static void after_work_cb(ns_work* req, int status) {
+  ASSERT(status == 0);
+  ASSERT(req == &work_req);
+  after_work_cb_count++;
+}
+
+static void after_work_cb2(ns_work*, int) {
+  FAIL("should not have been called");
+}
+
+
+TEST_CASE("threadpool_queue_work_simple", "[threadpool]") {
+  int r;
+
+  work_cb_count = 0;
+  after_work_cb_count = 0;
+
+  r = work_req.queue_work(uv_default_loop(), work_cb, after_work_cb, &data);
+  ASSERT(r == 0);
+  uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+
+  ASSERT(work_cb_count == 1);
+  ASSERT(after_work_cb_count == 1);
+
+  make_valgrind_happy();
+}
+
+
+TEST_CASE("threadpool_queue_work_simple2", "[threadpool]") {
+  int r;
+
+  work_cb_count = 0;
+  after_work_cb_count = 0;
+
+  r = work_req.queue_work(uv_default_loop(), work_cb, after_work_cb);
+  ASSERT(r == 0);
+  uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+
+  ASSERT(work_cb_count == 1);
+  ASSERT(after_work_cb_count == 1);
+
+  make_valgrind_happy();
+}
+
+
+TEST_CASE("threadpool_queue_work_no_after", "[threadpool]") {
+  int r;
+
+  work_cb_count = 0;
+  after_work_cb_count = 0;
+
+  r = work_req.queue_work(uv_default_loop(), work_cb, &data);
+  ASSERT(r == 0);
+  uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+
+  ASSERT(work_cb_count == 1);
+  ASSERT(after_work_cb_count == 0);
+
+  make_valgrind_happy();
+}
+
+
+TEST_CASE("threadpool_queue_work_no_after2", "[threadpool]") {
+  int r;
+
+  work_cb_count = 0;
+  after_work_cb_count = 0;
+
+  r = work_req.queue_work(uv_default_loop(), work_cb);
+  ASSERT(r == 0);
+  uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+
+  ASSERT(work_cb_count == 1);
+  ASSERT(after_work_cb_count == 0);
+
+  make_valgrind_happy();
+}
+
+
+TEST_CASE("threadpool_queue_work_einval", "[threadpool]") {
+  int r;
+
+  work_cb_count = 0;
+  after_work_cb_count = 0;
+
+  r = work_req.queue_work(uv_default_loop(), nullptr, after_work_cb2);
+  ASSERT(r == UV_EINVAL);
+
+  r = work_req.queue_work(uv_default_loop(), nullptr);
+  ASSERT(r == UV_EINVAL);
+
+  // I hope no one would do this, but we need to cover it anyways.
+  r = work_req.queue_work(uv_default_loop(),
+                          static_cast<void(*)(ns_work*, char*)>(nullptr),
+                          &data);
+  ASSERT(r == UV_EINVAL);
+
+  r = work_req.queue_work(uv_default_loop(),
+                          static_cast<void(*)(ns_work*, char*)>(nullptr),
+                          static_cast<void(*)(ns_work*, int, char*)>(nullptr),
+                          &data);
+  ASSERT(r == UV_EINVAL);
+
+  uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+
+  ASSERT(work_cb_count == 0);
+  ASSERT(after_work_cb_count == 0);
+
+  make_valgrind_happy();
+}


### PR DESCRIPTION
Implement uv_work_t in nsuv and include all related tests from libuv's test directory. The tests aren't beautiful, but they're clean and test all the correct things.

uv_work_t is unique since it inherits from uv_req_t, but doesn't have a default callback. Because of that, store the work_cb and after_cb and call them manually.