### PR TITLE
Improve Windows build support

### DIFF
--- a/include/nsuv-inl.h
+++ b/include/nsuv-inl.h
@@ -26,9 +26,15 @@ using util::addr_size;
 
 template <class UV_T, class R_T>
 template <typename CB, typename D_T>
-void ns_base_req<UV_T, R_T>::init(CB cb, D_T* data) {
+void ns_base_req<UV_T, R_T>::init(uv_loop_t* loop, CB cb, D_T* data) {
   req_cb_ = reinterpret_cast<void (*)()>(cb);
   req_cb_data_ = data;
+  loop_ = loop;
+}
+
+template <class UV_T, class R_T>
+uv_loop_t* ns_base_req<UV_T, R_T>::get_loop() {
+  return loop_;
 }
 
 template <class UV_T, class R_T>
@@ -292,7 +298,7 @@ int ns_addrinfo::get(uv_loop_t* loop,
                      const char* service,
                      const struct addrinfo* hints,
                      D_T* data) {
-  ns_base_req<uv_getaddrinfo_t, ns_addrinfo>::init(cb, data);
+  ns_base_req<uv_getaddrinfo_t, ns_addrinfo>::init(loop, cb, data);
   free();
 
   return uv_getaddrinfo(
@@ -309,7 +315,7 @@ int ns_addrinfo::get(uv_loop_t* loop,
                      const char* node,
                      const char* service,
                      const struct addrinfo* hints) {
-  ns_base_req<uv_getaddrinfo_t, ns_addrinfo>::init(cb);
+  ns_base_req<uv_getaddrinfo_t, ns_addrinfo>::init(loop, cb);
   free();
 
   return uv_getaddrinfo(loop,
@@ -390,7 +396,7 @@ int ns_fs::scandir_next(uv_dirent_t* ent) {
     return uv_fs_##name(nullptr, this, NSUV_PASS(P2), nullptr);                \
   }                                                                            \
   int ns_fs::name(uv_loop_t* loop, NSUV_PASS(P1), ns_fs_cb cb) {               \
-    ns_base_req<uv_fs_t, ns_fs>::init(cb);                                     \
+    ns_base_req<uv_fs_t, ns_fs>::init(loop, cb);                               \
     return uv_fs_##name(loop,                                                  \
                         this,                                                  \
                         NSUV_PASS(P2),                                         \
@@ -398,7 +404,7 @@ int ns_fs::scandir_next(uv_dirent_t* ent) {
   }                                                                            \
   template <typename D_T>                                                      \
   int ns_fs::name(uv_loop_t* loop, NSUV_PASS(P1), ns_fs_cb_d<D_T> cb, D_T* d) {\
-    ns_base_req<uv_fs_t, ns_fs>::init(cb, d);                                  \
+    ns_base_req<uv_fs_t, ns_fs>::init(loop, cb, d);                            \
     return uv_fs_##name(loop,                                                  \
                         this,                                                  \
                         NSUV_PASS(P2),                                         \
@@ -503,7 +509,7 @@ int ns_random::get(uv_loop_t* loop,
                    size_t buflen,
                    uint32_t flags,
                    ns_random_cb cb) {
-  ns_base_req<uv_random_t, ns_random>::init(cb);
+  ns_base_req<uv_random_t, ns_random>::init(loop, cb);
 
   return uv_random(loop,
                    this,
@@ -520,7 +526,7 @@ int ns_random::get(uv_loop_t* loop,
                    uint32_t flags,
                    ns_random_cb_d<D_T> cb,
                    D_T* data) {
-  ns_base_req<uv_random_t, ns_random>::init(cb, data);
+  ns_base_req<uv_random_t, ns_random>::init(loop, cb, data);
 
   return uv_random(loop,
                    this,

--- a/include/nsuv.h
+++ b/include/nsuv.h
@@ -83,9 +83,10 @@ template <class UV_T, class R_T>
 class ns_base_req : public UV_T {
  protected:
   template <typename CB, typename D_T = void>
-  NSUV_INLINE void init(CB cb, D_T* data = nullptr);
+  NSUV_INLINE void init(uv_loop_t* loop, CB cb, D_T* data = nullptr);
 
  public:
+  NSUV_INLINE uv_loop_t* get_loop();
   NSUV_INLINE UV_T* uv_req();
   NSUV_INLINE uv_req_t* base_req();
   NSUV_INLINE uv_req_type get_type();
@@ -104,6 +105,7 @@ class ns_base_req : public UV_T {
  protected:
   void (*req_cb_)() = nullptr;
   void* req_cb_data_ = nullptr;
+  uv_loop_t* loop_ = nullptr;
 };
 
 

--- a/test/test-fs.cc
+++ b/test/test-fs.cc
@@ -242,7 +242,7 @@ static void open_nametoolong_cb(ns_fs* req) {
   req->cleanup();
 }
 
-TEST_CASE("fs_file_nametoolong", "[wip]") {
+TEST_CASE("fs_file_nametoolong", "[fs]") {
   ns_fs req;
   uv_loop_t* loop;
   int r;

--- a/test/test-fs.cc
+++ b/test/test-fs.cc
@@ -2560,7 +2560,7 @@ TEST_CASE("fs_scandir_non_existent_dir", "[fs]") {
   req.cleanup();
 
   /* Fill the req to ensure that required fields are cleaned up */
-  memset(&req, 0xdb, sizeof(req.uv_req()));
+  memset(req.uv_req(), 0xdb, sizeof(*req.uv_req()));
 
   r = req.scandir(path, 0);
   ASSERT(r == UV_ENOENT);

--- a/test/test-tcp-connect-error-after-write.cc
+++ b/test/test-tcp-connect-error-after-write.cc
@@ -45,7 +45,6 @@ TEST_CASE("tcp_connect_error_after_write", "[tcp]") {
 #ifdef _WIN32
   fprintf(stderr, "This test is disabled on Windows for now.\n");
   fprintf(stderr, "See https://github.com/joyent/libuv/issues/444\n");
-  return 0; /* windows slackers... */
 #endif
 
   ASSERT(0 == uv_ip4_addr("127.0.0.1", kTestPort, &addr));

--- a/test/test-udp-open.cc
+++ b/test/test-udp-open.cc
@@ -157,8 +157,6 @@ TEST_CASE("udp_open", "[udp]") {
 
     client2.close();
   }
-#else  /* _WIN32 */
-  reinterpret_cast<void>(client2);
 #endif
 
   uv_run(uv_default_loop(), UV_RUN_DEFAULT);


### PR DESCRIPTION
On our way to getting the nsuv tests to build/run on Windows. Right now I can do that from MINGW having CMake and LLVM installed (w/ windows dev tools) doing:
```
$ clang -luv -lWs2_32 -o out/run_tests.exe test/test*.cc -I/path/to/libuv/include -L/path/to/libuv/build
```

Also add one feature of `ns_base_req::get_loop()` so that the loop can be retrieved from `ns_fs` callbacks.