### PR TITLE
use custom vector allocator to prevent exceptions

### DIFF
--- a/test/test-tcp-close.cc
+++ b/test/test-tcp-close.cc
@@ -35,13 +35,17 @@ static void connect_cb(ns_connect<ns_tcp>*, int status) {
 
 
 static void write_cb(ns_write<ns_tcp>* req, int status) {
+  const uv_buf_t* bufs;
+  size_t nbufs;
   /* write callbacks should run before the close callback */
   ASSERT_EQ(0, status);
   ASSERT_EQ(0, close_cb_called);
   ASSERT_EQ(req->handle(), &tcp_handle);
   write_cb_called++;
-  for (auto buf : req->bufs()) {
-    delete[] buf.base;
+  bufs = req->bufs();
+  nbufs = req->size();
+  for (size_t i = 0; i < nbufs; i++) {
+    delete[] bufs[i].base;
   }
   delete req;
 }


### PR DESCRIPTION
Since some programs will compile with -fno-exception and we want zero chance of this library causing the program to abort, switch to a custom Allocator for the vector storage of the uv_buf_t.

In order to do this we need to change the API to return the pointer instead of a reference to the vector.