### PR TITLE
src: make minor performance improvement

### DIFF
--- a/include/nsuv-inl.h
+++ b/include/nsuv-inl.h
@@ -626,7 +626,7 @@ uv_handle_t* ns_handle<UV_T, H_T>::base_handle() {
 
 template <class UV_T, class H_T>
 uv_loop_t* ns_handle<UV_T, H_T>::get_loop() {
-  return uv_handle_get_loop(base_handle());
+  return base_handle()->loop;
 }
 
 template <class UV_T, class H_T>


### PR DESCRIPTION
The call to uv_handle_get_loop() is not inlined, and adds a callq instruction to simply return a pointer. Instead return the pointer directly and save an instruction.