### PR TITLE
Add support for weak_ptr

### DIFF
--- a/include/nsuv-inl.h
+++ b/include/nsuv-inl.h
@@ -965,7 +965,7 @@ void ns_stream<UV_T, H_T>::alloc_proxy_(uv_handle_t* handle,
                                         size_t suggested_size,
                                         uv_buf_t* buf) {
   auto* server = H_T::cast(handle);
-  auto* cb_ = reinterpret_cast<CB_T>(server->listen_cb_ptr_);
+  auto* cb_ = reinterpret_cast<CB_T>(server->alloc_cb_ptr_);
   cb_(server, suggested_size, buf, static_cast<D_T*>(server->read_cb_data_));
 }
 

--- a/include/nsuv-inl.h
+++ b/include/nsuv-inl.h
@@ -29,6 +29,16 @@ void ns_base_req<UV_T, R_T>::init(uv_loop_t* loop, CB cb, D_T* data) {
 }
 
 template <class UV_T, class R_T>
+template <typename CB, typename D_T>
+void ns_base_req<UV_T, R_T>::init(uv_loop_t* loop,
+                                  CB cb,
+                                  std::weak_ptr<D_T> data) {
+  req_cb_ = reinterpret_cast<void (*)()>(cb);
+  req_cb_wp_ = data;
+  loop_ = loop;
+}
+
+template <class UV_T, class R_T>
 uv_loop_t* ns_base_req<UV_T, R_T>::get_loop() {
   return loop_;
 }
@@ -112,6 +122,13 @@ void ns_req<UV_T, R_T, H_T>::init(CB cb, D_T* data) {
 }
 
 template <class UV_T, class R_T, class H_T>
+template <typename CB, typename D_T>
+void ns_req<UV_T, R_T, H_T>::init(CB cb, std::weak_ptr<D_T> data) {
+  ns_base_req<UV_T, R_T>::req_cb_ = reinterpret_cast<void (*)()>(cb);
+  ns_base_req<UV_T, R_T>::req_cb_wp_ = data;
+}
+
+template <class UV_T, class R_T, class H_T>
 H_T* ns_req<UV_T, R_T, H_T>::handle() {
   return H_T::cast(static_cast<UV_T*>(this)->handle);
 }
@@ -126,6 +143,21 @@ void ns_req<UV_T, R_T, H_T>::handle(H_T* handle) {
 template <class H_T>
 template <typename CB, typename D_T>
 int ns_connect<H_T>::init(const struct sockaddr* addr, CB cb, D_T* data) {
+  int len = util::addr_size(addr);
+  if (len < 0)
+    return len;
+
+  ns_req<uv_connect_t, ns_connect<H_T>, H_T>::init(cb, data);
+  std::memcpy(&addr_, addr, len);
+
+  return NSUV_OK;
+}
+
+template <class H_T>
+template <typename CB, typename D_T>
+int ns_connect<H_T>::init(const struct sockaddr* addr,
+                          CB cb,
+                          std::weak_ptr<D_T> data) {
   int len = util::addr_size(addr);
   if (len < 0)
     return len;
@@ -161,6 +193,33 @@ template <typename CB, typename D_T>
 int ns_write<H_T>::init(const std::vector<uv_buf_t>& bufs,
                         CB cb,
                         D_T* data) {
+  ns_req<uv_write_t, ns_write<H_T>, H_T>::init(cb, data);
+
+  int er = bufs_.reserve(bufs.size());
+  if (er)
+    return er;
+  return bufs_.replace(bufs.data(), bufs.size());
+}
+
+template <class H_T>
+template <typename CB, typename D_T>
+int ns_write<H_T>::init(const uv_buf_t bufs[],
+                        size_t nbufs,
+                        CB cb,
+                        std::weak_ptr<D_T> data) {
+  ns_req<uv_write_t, ns_write<H_T>, H_T>::init(cb, data);
+
+  int er = bufs_.reserve(nbufs);
+  if (er)
+    return er;
+  return bufs_.replace(bufs, nbufs);
+}
+
+template <class H_T>
+template <typename CB, typename D_T>
+int ns_write<H_T>::init(const std::vector<uv_buf_t>& bufs,
+                        CB cb,
+                        std::weak_ptr<D_T> data) {
   ns_req<uv_write_t, ns_write<H_T>, H_T>::init(cb, data);
 
   int er = bufs_.reserve(bufs.size());
@@ -232,6 +291,57 @@ int ns_udp_send::init(const std::vector<uv_buf_t>& bufs,
     return er;
   return bufs_.replace(bufs.data(), bufs.size());
 }
+template <typename CB, typename D_T>
+int ns_udp_send::init(const uv_buf_t bufs[],
+                      size_t nbufs,
+                      const struct sockaddr* addr,
+                      CB cb,
+                      std::weak_ptr<D_T> data) {
+  ns_req<uv_udp_send_t, ns_udp_send, ns_udp>::init(cb, data);
+
+  if (addr != nullptr) {
+    addr_.reset(new (std::nothrow) struct sockaddr_storage());
+    if (addr == nullptr)
+      return UV_ENOMEM;
+
+    int len = util::addr_size(addr);
+    if (len < 0)
+      return len;
+
+    std::memcpy(addr_.get(), addr, len);
+  }
+
+  int er = bufs_.reserve(nbufs);
+  if (er)
+    return er;
+  return bufs_.replace(bufs, nbufs);
+}
+
+template <typename CB, typename D_T>
+int ns_udp_send::init(const std::vector<uv_buf_t>& bufs,
+                      const struct sockaddr* addr,
+                      CB cb,
+                      std::weak_ptr<D_T> data) {
+  ns_req<uv_udp_send_t, ns_udp_send, ns_udp>::init(cb, data);
+
+  if (addr != nullptr) {
+    addr_.reset(new (std::nothrow) struct sockaddr_storage());
+    if (addr == nullptr)
+      return UV_ENOMEM;
+
+    int len = util::addr_size(addr);
+    if (len < 0)
+      return len;
+
+    std::memcpy(addr_.get(), addr, len);
+  }
+
+  int er = bufs_.reserve(bufs.size());
+  if (er)
+    return er;
+  return bufs_.replace(bufs.data(), bufs.size());
+}
+
 
 const uv_buf_t* ns_udp_send::bufs() {
   return bufs_.data();
@@ -278,6 +388,25 @@ int ns_addrinfo::get(uv_loop_t* loop,
       hints);
 }
 
+template <typename D_T>
+int ns_addrinfo::get(uv_loop_t* loop,
+                     ns_addrinfo_cb_wp<D_T> cb,
+                     const char* node,
+                     const char* service,
+                     const struct addrinfo* hints,
+                     std::weak_ptr<D_T> data) {
+  ns_base_req<uv_getaddrinfo_t, ns_addrinfo>::init(loop, cb, data);
+  free();
+
+  return uv_getaddrinfo(
+      loop,
+      uv_req(),
+      util::check_null_cb(cb, &addrinfo_proxy_wp_<decltype(cb), D_T>),
+      node,
+      service,
+      hints);
+}
+
 int ns_addrinfo::get(uv_loop_t* loop,
                      ns_addrinfo_cb cb,
                      const char* node,
@@ -319,6 +448,16 @@ void ns_addrinfo::addrinfo_proxy_(uv_getaddrinfo_t* req,
   auto* ai_req = ns_addrinfo::cast(req);
   auto* cb_ = reinterpret_cast<CB_T>(ai_req->req_cb_);
   cb_(ai_req, status, static_cast<D_T*>(ai_req->req_cb_data_));
+}
+
+template <typename CB_T, typename D_T>
+void ns_addrinfo::addrinfo_proxy_wp_(uv_getaddrinfo_t* req,
+                                     int status,
+                                     struct addrinfo*) {
+  auto* ai_req = ns_addrinfo::cast(req);
+  auto* cb_ = reinterpret_cast<CB_T>(ai_req->req_cb_);
+  auto data = ai_req->req_cb_wp_.lock();
+  cb_(ai_req, status, std::static_pointer_cast<D_T>(data));
 }
 
 
@@ -378,6 +517,18 @@ int ns_fs::scandir_next(uv_dirent_t* ent) {
       this,                                                                    \
       NSUV_PASS(P2),                                                           \
       util::check_null_cb(cb, &cb_proxy_<decltype(cb), D_T>));                 \
+  }                                                                            \
+  template <typename D_T>                                                      \
+  int ns_fs::name(uv_loop_t* loop,                                             \
+                  NSUV_PASS(P1),                                               \
+                  ns_fs_cb_wp<D_T> cb,                                         \
+                  std::weak_ptr<D_T> d) {                                      \
+    ns_base_req<uv_fs_t, ns_fs>::init(loop, cb, d);                            \
+    return uv_fs_##name(                                                       \
+      loop,                                                                    \
+      this,                                                                    \
+      NSUV_PASS(P2),                                                           \
+      util::check_null_cb(cb, &cb_proxy_wp_<decltype(cb), D_T>));              \
   }
 
 NSUV_FS_FN(close, (uv_file file), (file))
@@ -466,6 +617,14 @@ void ns_fs::cb_proxy_(uv_fs_t* req) {
   cb(fs_req, static_cast<D_T*>(fs_req->req_cb_data_));
 }
 
+template <typename CB_T, typename D_T>
+void ns_fs::cb_proxy_wp_(uv_fs_t* req) {
+  auto* fs_req = ns_fs::cast(req);
+  auto* cb = reinterpret_cast<CB_T>(fs_req->req_cb_);
+  auto data = fs_req->req_cb_wp_.lock();
+  cb(fs_req, std::static_pointer_cast<D_T>(data));
+}
+
 
 /* ns_random */
 
@@ -505,6 +664,24 @@ int ns_random::get(uv_loop_t* loop,
                    util::check_null_cb(cb, &random_proxy_<decltype(cb), D_T>));
 }
 
+template <typename D_T>
+int ns_random::get(uv_loop_t* loop,
+                   void* buf,
+                   size_t buflen,
+                   uint32_t flags,
+                   ns_random_cb_wp<D_T> cb,
+                   std::weak_ptr<D_T> data) {
+  ns_base_req<uv_random_t, ns_random>::init(loop, cb, data);
+
+  return uv_random(
+      loop,
+      this,
+      buf,
+      buflen,
+      flags,
+      util::check_null_cb(cb, &random_proxy_wp_<decltype(cb), D_T>));
+}
+
 template <typename CB_T>
 void ns_random::random_proxy_(uv_random_t* req,
                               int status,
@@ -523,6 +700,17 @@ void ns_random::random_proxy_(uv_random_t* req,
   auto* r_req = ns_random::cast(req);
   auto* cb = reinterpret_cast<CB_T>(r_req->req_cb_);
   cb(r_req, status, buf, buflen, static_cast<D_T*>(r_req->req_cb_data_));
+}
+
+template <typename CB_T, typename D_T>
+void ns_random::random_proxy_wp_(uv_random_t* req,
+                                 int status,
+                                 void* buf,
+                                 size_t buflen) {
+  auto* r_req = ns_random::cast(req);
+  auto* cb = reinterpret_cast<CB_T>(r_req->req_cb_);
+  auto data = r_req->req_cb_wp_.lock();
+  cb(r_req, status, buf, buflen, std::static_pointer_cast<D_T>(data));
 }
 
 
@@ -559,6 +747,24 @@ int ns_work::queue_work(uv_loop_t* loop,
       util::check_null_cb(after_cb, &after_proxy_<decltype(after_cb), D_T>));
 }
 
+template <typename D_T>
+int ns_work::queue_work(uv_loop_t* loop,
+                        ns_work_cb_wp<D_T> work_cb,
+                        ns_after_work_cb_wp<D_T> after_cb,
+                        std::weak_ptr<D_T> data) {
+  work_cb_ptr_ = reinterpret_cast<void (*)()>(work_cb);
+  after_cb_ptr_ = reinterpret_cast<void (*)()>(after_cb);
+  cb_wp_ = data;
+
+  // Need a nullptr check in case someone decides to static_cast a nullptr to
+  // the work_cb sig. Yes the user shouldn't do this but still need to check.
+  return uv_queue_work(
+      loop,
+      this,
+      util::check_null_cb(work_cb, &work_proxy_wp_<decltype(work_cb), D_T>),
+      util::check_null_cb(after_cb, &after_proxy_wp_<decltype(after_cb), D_T>));
+}
+
 int ns_work::queue_work(uv_loop_t* loop, ns_work_cb work_cb) {
   work_cb_ptr_ = reinterpret_cast<void (*)()>(work_cb);
 
@@ -580,6 +786,20 @@ int ns_work::queue_work(uv_loop_t* loop,
       loop,
       this,
       util::check_null_cb(work_cb, &work_proxy_<decltype(work_cb), D_T>),
+      nullptr);
+}
+
+template <typename D_T>
+int ns_work::queue_work(uv_loop_t* loop,
+                        ns_work_cb_wp<D_T> work_cb,
+                        std::weak_ptr<D_T> data) {
+  work_cb_ptr_ = reinterpret_cast<void (*)()>(work_cb);
+  cb_wp_ = data;
+
+  return uv_queue_work(
+      loop,
+      this,
+      util::check_null_cb(work_cb, &work_proxy_wp_<decltype(work_cb), D_T>),
       nullptr);
 }
 
@@ -605,10 +825,26 @@ void ns_work::work_proxy_(uv_work_t* req) {
 }
 
 template <typename CB_T, typename D_T>
+void ns_work::work_proxy_wp_(uv_work_t* req) {
+  auto* w_req = ns_work::cast(req);
+  auto* cb = reinterpret_cast<CB_T>(w_req->work_cb_ptr_);
+  auto data = w_req->cb_wp_.lock();
+  cb(w_req, std::static_pointer_cast<D_T>(data));
+}
+
+template <typename CB_T, typename D_T>
 void ns_work::after_proxy_(uv_work_t* req, int status) {
   auto* w_req = ns_work::cast(req);
   auto* cb = reinterpret_cast<CB_T>(w_req->after_cb_ptr_);
   cb(w_req, status, static_cast<D_T*>(w_req->cb_data_));
+}
+
+template <typename CB_T, typename D_T>
+void ns_work::after_proxy_wp_(uv_work_t* req, int status) {
+  auto* w_req = ns_work::cast(req);
+  auto* cb = reinterpret_cast<CB_T>(w_req->after_cb_ptr_);
+  auto data = w_req->cb_wp_.lock();
+  cb(w_req, status, std::static_pointer_cast<D_T>(data));
 }
 
 
@@ -696,6 +932,16 @@ void ns_handle<UV_T, H_T>::close(void (*cb)(H_T*, void*), std::nullptr_t) {
 }
 
 template <class UV_T, class H_T>
+template <typename D_T>
+void ns_handle<UV_T, H_T>::close(ns_close_cb_wp<D_T> cb,
+                                 std::weak_ptr<D_T> data) {
+  close_cb_ptr_ = reinterpret_cast<void (*)()>(cb);
+  close_cb_wp_ = data;
+  uv_close(base_handle(),
+           util::check_null_cb(cb, &close_proxy_wp_<decltype(cb), D_T>));
+}
+
+template <class UV_T, class H_T>
 void ns_handle<UV_T, H_T>::close_and_delete() {
   if (get_type() == UV_UNKNOWN_HANDLE) {
     delete H_T::cast(base_handle());
@@ -749,6 +995,15 @@ void ns_handle<UV_T, H_T>::close_proxy_(uv_handle_t* handle) {
   H_T* wrap = H_T::cast(handle);
   auto* cb_ = reinterpret_cast<CB_T>(wrap->close_cb_ptr_);
   cb_(wrap, static_cast<D_T*>(wrap->close_cb_data_));
+}
+
+template <class UV_T, class H_T>
+template <typename CB_T, typename D_T>
+void ns_handle<UV_T, H_T>::close_proxy_wp_(uv_handle_t* handle) {
+  H_T* wrap = H_T::cast(handle);
+  auto* cb_ = reinterpret_cast<CB_T>(wrap->close_cb_ptr_);
+  auto data = wrap->close_cb_wp_.lock();
+  cb_(wrap, std::static_pointer_cast<D_T>(data));
 }
 
 template <class UV_T, class H_T>
@@ -814,6 +1069,20 @@ int ns_stream<UV_T, H_T>::listen(int backlog,
 }
 
 template <class UV_T, class H_T>
+template <typename D_T>
+int ns_stream<UV_T, H_T>::listen(int backlog,
+                                 ns_listen_cb_wp<D_T> cb,
+                                 std::weak_ptr<D_T> data) {
+  listen_cb_ptr_ = reinterpret_cast<void (*)()>(cb);
+  listen_cb_wp_ = data;
+
+  return uv_listen(
+      base_stream(),
+      backlog,
+      util::check_null_cb(cb, &listen_proxy_wp_<decltype(cb), D_T>));
+}
+
+template <class UV_T, class H_T>
 int ns_stream<UV_T, H_T>::accept(H_T* handle) {
   return uv_accept(base_stream(), handle->base_stream());
 }
@@ -843,6 +1112,21 @@ int ns_stream<UV_T, H_T>::read_start(ns_alloc_cb_d<D_T> alloc_cb,
       base_stream(),
       util::check_null_cb(alloc_cb, &alloc_proxy_<decltype(alloc_cb), D_T>),
       util::check_null_cb(read_cb, &read_proxy_<decltype(read_cb), D_T>));
+}
+
+template <class UV_T, class H_T>
+template <typename D_T>
+int ns_stream<UV_T, H_T>::read_start(ns_alloc_cb_wp<D_T> alloc_cb,
+                                     ns_read_cb_wp<D_T> read_cb,
+                                     std::weak_ptr<D_T> data) {
+  alloc_cb_ptr_ = reinterpret_cast<void (*)()>(alloc_cb);
+  read_cb_ptr_ = reinterpret_cast<void (*)()>(read_cb);
+  read_cb_wp_ = data;
+
+  return uv_read_start(
+      base_stream(),
+      util::check_null_cb(alloc_cb, &alloc_proxy_wp_<decltype(alloc_cb), D_T>),
+      util::check_null_cb(read_cb, &read_proxy_wp_<decltype(read_cb), D_T>));
 }
 
 template <class UV_T, class H_T>
@@ -911,6 +1195,24 @@ int ns_stream<UV_T, H_T>::write(ns_write<H_T>* req,
 template <class UV_T, class H_T>
 template <typename D_T>
 int ns_stream<UV_T, H_T>::write(ns_write<H_T>* req,
+                                const uv_buf_t bufs[],
+                                size_t nbufs,
+                                ns_write_cb_wp<D_T> cb,
+                                std::weak_ptr<D_T> data) {
+  int ret = req->init(bufs, nbufs, cb, data);
+  if (ret != NSUV_OK)
+    return ret;
+
+  return uv_write(req->uv_req(),
+                  base_stream(),
+                  req->bufs(),
+                  req->size(),
+                  util::check_null_cb(cb, &write_proxy_wp_<decltype(cb), D_T>));
+}
+
+template <class UV_T, class H_T>
+template <typename D_T>
+int ns_stream<UV_T, H_T>::write(ns_write<H_T>* req,
                                 const std::vector<uv_buf_t>& bufs,
                                 ns_write_cb_d<D_T> cb,
                                 D_T* data) {
@@ -934,6 +1236,23 @@ int ns_stream<UV_T, H_T>::write(ns_write<H_T>* req,
 }
 
 template <class UV_T, class H_T>
+template <typename D_T>
+int ns_stream<UV_T, H_T>::write(ns_write<H_T>* req,
+                                const std::vector<uv_buf_t>& bufs,
+                                ns_write_cb_wp<D_T> cb,
+                                std::weak_ptr<D_T> data) {
+  int ret = req->init(bufs, cb, data);
+  if (ret != NSUV_OK)
+    return ret;
+
+  return uv_write(req->uv_req(),
+                  base_stream(),
+                  req->bufs(),
+                  req->size(),
+                  util::check_null_cb(cb, &write_proxy_wp_<decltype(cb), D_T>));
+}
+
+template <class UV_T, class H_T>
 template <typename CB_T>
 void ns_stream<UV_T, H_T>::listen_proxy_(uv_stream_t* handle, int status) {
   auto* server = H_T::cast(handle);
@@ -947,6 +1266,15 @@ void ns_stream<UV_T, H_T>::listen_proxy_(uv_stream_t* handle, int status) {
   auto* server = H_T::cast(handle);
   auto* cb_ = reinterpret_cast<CB_T>(server->listen_cb_ptr_);
   cb_(server, status, static_cast<D_T*>(server->listen_cb_data_));
+}
+
+template <class UV_T, class H_T>
+template <typename CB_T, typename D_T>
+void ns_stream<UV_T, H_T>::listen_proxy_wp_(uv_stream_t* handle, int status) {
+  auto* server = H_T::cast(handle);
+  auto* cb_ = reinterpret_cast<CB_T>(server->listen_cb_ptr_);
+  auto data = server->listen_cb_wp_.lock();
+  cb_(server, status, std::static_pointer_cast<D_T>(data));
 }
 
 template <class UV_T, class H_T>
@@ -970,6 +1298,17 @@ void ns_stream<UV_T, H_T>::alloc_proxy_(uv_handle_t* handle,
 }
 
 template <class UV_T, class H_T>
+template <typename CB_T, typename D_T>
+void ns_stream<UV_T, H_T>::alloc_proxy_wp_(uv_handle_t* handle,
+                                           size_t suggested_size,
+                                           uv_buf_t* buf) {
+  auto* server = H_T::cast(handle);
+  auto* cb_ = reinterpret_cast<CB_T>(server->alloc_cb_ptr_);
+  auto data = server->read_cb_wp_.lock();
+  cb_(server, suggested_size, buf, std::static_pointer_cast<D_T>(data));
+}
+
+template <class UV_T, class H_T>
 template <typename CB_T>
 void ns_stream<UV_T, H_T>::read_proxy_(uv_stream_t* handle,
                                        ssize_t nread,
@@ -990,6 +1329,17 @@ void ns_stream<UV_T, H_T>::read_proxy_(uv_stream_t* handle,
 }
 
 template <class UV_T, class H_T>
+template <typename CB_T, typename D_T>
+void ns_stream<UV_T, H_T>::read_proxy_wp_(uv_stream_t* handle,
+                                          ssize_t nread,
+                                          const uv_buf_t* buf) {
+  auto* server = H_T::cast(handle);
+  auto* cb_ = reinterpret_cast<CB_T>(server->read_cb_ptr_);
+  auto data = server->read_cb_wp_.lock();
+  cb_(server, nread, buf, std::static_pointer_cast<D_T>(data));
+}
+
+template <class UV_T, class H_T>
 template <typename CB_T>
 void ns_stream<UV_T, H_T>::write_proxy_(uv_write_t* uv_req, int status) {
   auto* wreq = ns_write<H_T>::cast(uv_req);
@@ -1003,6 +1353,15 @@ void ns_stream<UV_T, H_T>::write_proxy_(uv_write_t* uv_req, int status) {
   auto* wreq = ns_write<H_T>::cast(uv_req);
   auto* cb_ = reinterpret_cast<CB_T>(wreq->req_cb_);
   cb_(wreq, status, static_cast<D_T*>(wreq->req_cb_data_));
+}
+
+template <class UV_T, class H_T>
+template <typename CB_T, typename D_T>
+void ns_stream<UV_T, H_T>::write_proxy_wp_(uv_write_t* uv_req, int status) {
+  auto* wreq = ns_write<H_T>::cast(uv_req);
+  auto* cb_ = reinterpret_cast<CB_T>(wreq->req_cb_);
+  auto data = wreq->req_cb_wp_.lock();
+  cb_(wreq, status, std::static_pointer_cast<D_T>(data));
 }
 
 
@@ -1034,6 +1393,19 @@ int ns_async::init(uv_loop_t* loop,
   return init(loop, cb, NSUV_CAST_NULLPTR);
 }
 
+template <typename D_T>
+int ns_async::init(uv_loop_t* loop,
+                   ns_async_cb_wp<D_T> cb,
+                   std::weak_ptr<D_T> data) {
+  async_cb_ptr_ = reinterpret_cast<void (*)()>(cb);
+  async_cb_wp_ = data;
+
+  return uv_async_init(
+    loop,
+    uv_handle(),
+    util::check_null_cb(cb, &async_proxy_wp_<decltype(cb), D_T>));
+}
+
 int ns_async::send() {
   return uv_async_send(uv_handle());
 }
@@ -1050,6 +1422,14 @@ void ns_async::async_proxy_(uv_async_t* handle) {
   auto* wrap = ns_async::cast(handle);
   auto* cb_ = reinterpret_cast<CB_T>(wrap->async_cb_ptr_);
   cb_(wrap, static_cast<D_T*>(wrap->async_cb_data_));
+}
+
+template <typename CB_T, typename D_T>
+void ns_async::async_proxy_wp_(uv_async_t* handle) {
+  auto* wrap = ns_async::cast(handle);
+  auto* cb_ = reinterpret_cast<CB_T>(wrap->async_cb_ptr_);
+  auto data = wrap->async_cb_wp_.lock();
+  cb_(wrap, std::static_pointer_cast<D_T>(data));
 }
 
 
@@ -1094,6 +1474,19 @@ int ns_poll::start(int events,
   return start(events, cb, NSUV_CAST_NULLPTR);
 }
 
+template <typename D_T>
+int ns_poll::start(int events,
+                   ns_poll_cb_wp<D_T> cb,
+                   std::weak_ptr<D_T> data) {
+  poll_cb_ptr_ = reinterpret_cast<void (*)()>(cb);
+  poll_cb_wp_ = data;
+
+  return uv_poll_start(
+    uv_handle(),
+    events,
+    util::check_null_cb(cb, &poll_proxy_wp_<decltype(cb), D_T>));
+}
+
 int ns_poll::stop() {
   return uv_poll_stop(uv_handle());
 }
@@ -1110,6 +1503,14 @@ void ns_poll::poll_proxy_(uv_poll_t* handle, int poll, int events) {
   ns_poll* wrap = ns_poll::cast(handle);
   auto* cb_ = reinterpret_cast<CB_T>(wrap->poll_cb_ptr_);
   cb_(wrap, poll, events, static_cast<D_T*>(wrap->poll_cb_data_));
+}
+
+template <typename CB_T, typename D_T>
+void ns_poll::poll_proxy_wp_(uv_poll_t* handle, int poll, int events) {
+  ns_poll* wrap = ns_poll::cast(handle);
+  auto* cb_ = reinterpret_cast<CB_T>(wrap->poll_cb_ptr_);
+  auto data = wrap->poll_cb_wp_.lock();
+  cb_(wrap, poll, events, std::static_pointer_cast<D_T>(data));
 }
 
 
@@ -1172,6 +1573,16 @@ int ns_tcp::close_reset(void (*cb)(ns_tcp*, void*), std::nullptr_t) {
   return close_reset(cb, NSUV_CAST_NULLPTR);
 }
 
+template <typename D_T>
+int ns_tcp::close_reset(ns_close_cb_wp<D_T> cb, std::weak_ptr<D_T> data) {
+  close_reset_cb_ptr_ = reinterpret_cast<void (*)()>(cb);
+  close_reset_wp_ = data;
+
+  return uv_tcp_close_reset(
+      uv_handle(),
+      util::check_null_cb(cb, &close_reset_proxy_wp_<decltype(cb), D_T>));
+}
+
 int ns_tcp::connect(ns_connect<ns_tcp>* req,
                     const struct sockaddr* addr,
                     ns_connect_cb cb) {
@@ -1209,6 +1620,22 @@ int ns_tcp::connect(ns_connect<ns_tcp>* req,
   return connect(req, addr, cb, NSUV_CAST_NULLPTR);
 }
 
+template <typename D_T>
+int ns_tcp::connect(ns_connect<ns_tcp>* req,
+                    const struct sockaddr* addr,
+                    ns_connect_cb_wp<D_T> cb,
+                    std::weak_ptr<D_T> data) {
+  int ret = req->init(addr, cb, data);
+  if (ret != NSUV_OK)
+    return ret;
+
+  return uv_tcp_connect(
+      req->uv_req(),
+      uv_handle(),
+      addr,
+      util::check_null_cb(cb, &connect_proxy_wp_<decltype(cb), D_T>));
+}
+
 template <typename CB_T>
 void ns_tcp::connect_proxy_(uv_connect_t* uv_req, int status) {
   auto* creq = ns_connect<ns_tcp>::cast(uv_req);
@@ -1223,6 +1650,14 @@ void ns_tcp::connect_proxy_(uv_connect_t* uv_req, int status) {
   cb_(creq, status, static_cast<D_T*>(creq->req_cb_data_));
 }
 
+template <typename CB_T, typename D_T>
+void ns_tcp::connect_proxy_wp_(uv_connect_t* uv_req, int status) {
+  auto* creq = ns_connect<ns_tcp>::cast(uv_req);
+  auto* cb_ = reinterpret_cast<CB_T>(creq->req_cb_);
+  auto data = creq->req_cb_wp_.lock();
+  cb_(creq, status, std::static_pointer_cast<D_T>(data));
+}
+
 template <typename CB_T>
 void ns_tcp::close_reset_proxy_(uv_handle_t* handle) {
   ns_tcp* wrap = ns_tcp::cast(handle);
@@ -1235,6 +1670,14 @@ void ns_tcp::close_reset_proxy_(uv_handle_t* handle) {
   ns_tcp* wrap = ns_tcp::cast(handle);
   auto* cb = reinterpret_cast<CB_T>(wrap->close_reset_cb_ptr_);
   cb(wrap, static_cast<D_T*>(wrap->close_reset_data_));
+}
+
+template <typename CB_T, typename D_T>
+void ns_tcp::close_reset_proxy_wp_(uv_handle_t* handle) {
+  ns_tcp* wrap = ns_tcp::cast(handle);
+  auto* cb = reinterpret_cast<CB_T>(wrap->close_reset_cb_ptr_);
+  auto data = wrap->close_reset_wp_.lock();
+  cb(wrap, std::static_pointer_cast<D_T>(data));
 }
 
 
@@ -1277,6 +1720,21 @@ int ns_timer::start(void (*cb)(ns_timer*, void*),
   return start(cb, timeout, repeat, NSUV_CAST_NULLPTR);
 }
 
+template <typename D_T>
+int ns_timer::start(ns_timer_cb_wp<D_T> cb,
+                    uint64_t timeout,
+                    uint64_t repeat,
+                    std::weak_ptr<D_T> data) {
+  timer_cb_ptr_ = reinterpret_cast<void (*)()>(cb);
+  timer_cb_wp_ = data;
+
+  return uv_timer_start(
+    uv_handle(),
+    util::check_null_cb(cb, &timer_proxy_wp_<decltype(cb), D_T>),
+    timeout,
+    repeat);
+}
+
 int ns_timer::stop() {
   return uv_timer_stop(uv_handle());
 }
@@ -1297,6 +1755,14 @@ void ns_timer::timer_proxy_(uv_timer_t* handle) {
   ns_timer* wrap = ns_timer::cast(handle);
   auto* cb_ = reinterpret_cast<CB_T>(wrap->timer_cb_ptr_);
   cb_(wrap, static_cast<D_T*>(wrap->timer_cb_data_));
+}
+
+template <typename CB_T, typename D_T>
+void ns_timer::timer_proxy_wp_(uv_timer_t* handle) {
+  ns_timer* wrap = ns_timer::cast(handle);
+  auto* cb_ = reinterpret_cast<CB_T>(wrap->timer_cb_ptr_);
+  auto data = wrap->timer_cb_wp_.lock();
+  cb_(wrap, std::static_pointer_cast<D_T>(data));
 }
 
 
@@ -1333,6 +1799,17 @@ void ns_timer::timer_proxy_(uv_timer_t* handle) {
     return start(cb, NSUV_CAST_NULLPTR);                                       \
   }                                                                            \
                                                                                \
+  template <typename D_T>                                                      \
+  int ns_##name::start(ns_##name##_cb_wp<D_T> cb, std::weak_ptr<D_T> data) {   \
+    if (is_active())                                                           \
+      return 0;                                                                \
+    name##_cb_ptr_ = reinterpret_cast<void (*)()>(cb);                         \
+    name##_cb_wp_ = data;                                                      \
+    return uv_##name##_start(                                                  \
+        uv_handle(),                                                           \
+        util::check_null_cb(cb, &name##_proxy_wp_<decltype(cb), D_T>));        \
+  }                                                                            \
+                                                                               \
   int ns_##name::stop() { return uv_##name##_stop(uv_handle()); }              \
                                                                                \
   template <typename CB_T>                                                     \
@@ -1347,6 +1824,14 @@ void ns_timer::timer_proxy_(uv_timer_t* handle) {
     ns_##name* wrap = ns_##name::cast(handle);                                 \
     auto* cb_ = reinterpret_cast<CB_T>(wrap->name##_cb_ptr_);                  \
     cb_(wrap, static_cast<D_T*>(wrap->name##_cb_data_));                       \
+  }                                                                            \
+                                                                               \
+  template <typename CB_T, typename D_T>                                       \
+  void ns_##name::name##_proxy_wp_(uv_##name##_t* handle) {                    \
+    ns_##name* wrap = ns_##name::cast(handle);                                 \
+    auto* cb_ = reinterpret_cast<CB_T>(wrap->name##_cb_ptr_);                  \
+    auto data = wrap->name##_cb_wp_.lock();                                    \
+    cb_(wrap, std::static_pointer_cast<D_T>(data));                            \
   }
 
 
@@ -1522,6 +2007,26 @@ int ns_udp::send(ns_udp_send* req,
 
 template <typename D_T>
 int ns_udp::send(ns_udp_send* req,
+                 const uv_buf_t bufs[],
+                 size_t nbufs,
+                 const struct sockaddr* addr,
+                 ns_udp_send_cb_wp<D_T> cb,
+                 std::weak_ptr<D_T> data) {
+  int r = req->init(bufs, nbufs, addr, cb, data);
+  if (r != 0)
+    return r;
+
+  return uv_udp_send(
+      req->uv_req(),
+      uv_handle(),
+      req->bufs(),
+      req->size(),
+      addr,
+      util::check_null_cb(cb, &send_proxy_wp_<decltype(cb), D_T>));
+}
+
+template <typename D_T>
+int ns_udp::send(ns_udp_send* req,
                  const std::vector<uv_buf_t>& bufs,
                  const struct sockaddr* addr,
                  ns_udp_send_cb_d<D_T> cb,
@@ -1544,6 +2049,25 @@ int ns_udp::send(ns_udp_send* req,
                  void (*cb)(ns_udp_send*, int, void*),
                  std::nullptr_t) {
   return send(req, bufs, addr, cb, NSUV_CAST_NULLPTR);
+}
+
+template <typename D_T>
+int ns_udp::send(ns_udp_send* req,
+                 const std::vector<uv_buf_t>& bufs,
+                 const struct sockaddr* addr,
+                 ns_udp_send_cb_wp<D_T> cb,
+                 std::weak_ptr<D_T> data) {
+  int r = req->init(bufs, addr, cb, data);
+  if (r != 0)
+    return r;
+
+  return uv_udp_send(
+      req->uv_req(),
+      uv_handle(),
+      req->bufs(),
+      req->size(),
+      addr,
+      util::check_null_cb(cb, &send_proxy_wp_<decltype(cb), D_T>));
 }
 
 const sockaddr* ns_udp::local_addr() {
@@ -1579,6 +2103,14 @@ void ns_udp::send_proxy_(uv_udp_send_t* uv_req, int status) {
   auto* ureq = ns_udp_send::cast(uv_req);
   auto* cb_ = reinterpret_cast<CB_T>(ureq->req_cb_);
   cb_(ureq, status, static_cast<D_T*>(ureq->req_cb_data_));
+}
+
+template <typename CB_T, typename D_T>
+void ns_udp::send_proxy_wp_(uv_udp_send_t* uv_req, int status) {
+  auto* ureq = ns_udp_send::cast(uv_req);
+  auto* cb_ = reinterpret_cast<CB_T>(ureq->req_cb_);
+  auto data = ureq->req_cb_wp_.lock();
+  cb_(ureq, status, std::static_pointer_cast<D_T>(data));
 }
 
 
@@ -1748,6 +2280,17 @@ int ns_thread::create(void (*cb)(ns_thread*, void*), std::nullptr_t) {
   return create(cb, NSUV_CAST_NULLPTR);
 }
 
+template <typename D_T>
+int ns_thread::create(ns_thread_cb_wp<D_T> cb, std::weak_ptr<D_T> data) {
+  thread_cb_ptr_ = reinterpret_cast<void (*)()>(cb);
+  thread_cb_wp_ = data;
+
+  return uv_thread_create(
+      &thread_,
+      util::check_null_cb(cb, &create_proxy_wp_<decltype(cb), D_T>),
+      this);
+}
+
 int ns_thread::create_ex(const uv_thread_options_t* params,
                          ns_thread_cb cb) {
   thread_cb_ptr_ = reinterpret_cast<void (*)()>(cb);
@@ -1777,6 +2320,20 @@ int ns_thread::create_ex(const uv_thread_options_t* params,
                          void (*cb)(ns_thread*, void*),
                          std::nullptr_t) {
   return create_ex(params, cb, NSUV_CAST_NULLPTR);
+}
+
+template <typename D_T>
+int ns_thread::create_ex(const uv_thread_options_t* params,
+                         ns_thread_cb_wp<D_T> cb,
+                         std::weak_ptr<D_T> data) {
+  thread_cb_ptr_ = reinterpret_cast<void (*)()>(cb);
+  thread_cb_wp_ = data;
+
+  return uv_thread_create_ex(
+      &thread_,
+      params,
+      util::check_null_cb(cb, &create_proxy_wp_<decltype(cb), D_T>),
+      this);
 }
 
 int ns_thread::join() {
@@ -1827,6 +2384,14 @@ void ns_thread::create_proxy_(void* arg) {
   auto* wrap = static_cast<ns_thread*>(arg);
   auto* cb_ = reinterpret_cast<CB_T>(wrap->thread_cb_ptr_);
   cb_(wrap, static_cast<D_T*>(wrap->thread_cb_data_));
+}
+
+template <typename CB_T, typename D_T>
+void ns_thread::create_proxy_wp_(void* arg) {
+  auto* wrap = static_cast<ns_thread*>(arg);
+  auto* cb_ = reinterpret_cast<CB_T>(wrap->thread_cb_ptr_);
+  auto data = wrap->thread_cb_wp_.lock();
+  cb_(wrap, std::static_pointer_cast<D_T>(data));
 }
 
 int util::addr_size(const struct sockaddr* addr) {

--- a/test/helpers.h
+++ b/test/helpers.h
@@ -33,6 +33,12 @@ constexpr char kTestPipename3[] = "/tmp/uv-test-sock3";
 
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
 
+// Because nsuv has a void* overload C++ doesn't know how to properly cast from
+// a std::shared_ptr to std::weak_ptr implicitly. Create a macro so we can do it
+// inline.
+// NOLINTNEXTLINE
+#define TO_WEAK(a) (std::weak_ptr<typename std::remove_pointer<decltype((a).get())>::type>(a))
+
 // TODO(trevnorris): This is temporary while libuv tests are being ported. A
 // more permanent solution should be made.
 #define container_of(ptr, type, member)                                       \

--- a/test/test-addrinfo-wp.cc
+++ b/test/test-addrinfo-wp.cc
@@ -1,0 +1,102 @@
+#include "../include/nsuv-inl.h"
+#include "./catch.hpp"
+#include "./helpers.h"
+
+using nsuv::ns_addrinfo;
+
+static const char* invalid_name = "xyzzy.xyzzy.xyzzy.";
+static const char* valid_name = "localhost";
+
+static std::string* my_data_ptr = nullptr;
+
+static void gettaddrinfo_failure_cb(ns_addrinfo* info,
+                                    int status,
+                                    std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  ASSERT_GT(0, status);
+  ASSERT_NULL(info->info());
+}
+
+TEST_CASE("invalid_get_async_wp", "[addrinfo]") {
+  std::shared_ptr<size_t> sp = std::make_shared<size_t>(42);
+  ns_addrinfo info;
+
+  ASSERT_EQ(0, info.get(uv_default_loop(),
+                        gettaddrinfo_failure_cb,
+                        invalid_name,
+                        nullptr,
+                        nullptr,
+                        TO_WEAK(sp)));
+
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+
+  make_valgrind_happy();
+}
+
+static void gettaddrinfo_success_cb(ns_addrinfo* info,
+                                    int status,
+                                    std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  ASSERT_EQ(0, status);
+  ASSERT(info->info());
+}
+
+TEST_CASE("valid_get_async_wp", "[addrinfo]") {
+  std::shared_ptr<size_t> sp = std::make_shared<size_t>(42);
+  ns_addrinfo info;
+
+  ASSERT_EQ(0, info.get(uv_default_loop(),
+                        gettaddrinfo_success_cb,
+                        valid_name,
+                        nullptr,
+                        nullptr,
+                        TO_WEAK(sp)));
+
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+
+  make_valgrind_happy();
+}
+
+static void gettaddrinfo_void_data_cb(ns_addrinfo* info,
+                                      int status,
+                                      std::weak_ptr<std::string> d) {
+  auto data = d.lock();
+  ASSERT_EQ(0, status);
+  ASSERT(info->info());
+  ASSERT(data);
+  ASSERT_EQ(data.get(), my_data_ptr);
+}
+
+TEST_CASE("valid_get_async_void_data_wp", "[addrinfo]") {
+  auto my_data = std::make_shared<std::string>("my_data");
+  std::weak_ptr<std::string> wp = my_data;
+  ns_addrinfo info;
+  struct addrinfo hints;
+
+  my_data_ptr = my_data.get();
+
+  memset(&hints, 0, sizeof(struct addrinfo));
+  hints.ai_family = AF_UNSPEC;    /* Allow IPv4 or IPv6 */
+  hints.ai_socktype = SOCK_DGRAM; /* Datagram socket */
+  hints.ai_flags = AI_PASSIVE;    /* For wildcard IP address */
+  hints.ai_protocol = 0;          /* Any protocol */
+  hints.ai_canonname = nullptr;
+  hints.ai_addr = nullptr;
+  hints.ai_next = nullptr;
+
+  ASSERT_EQ(0, info.get(uv_default_loop(),
+                        gettaddrinfo_void_data_cb,
+                        valid_name,
+                        nullptr,
+                        &hints,
+                        wp));
+
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+
+  my_data_ptr = nullptr;
+  make_valgrind_happy();
+}

--- a/test/test-async-wp.cc
+++ b/test/test-async-wp.cc
@@ -1,0 +1,93 @@
+#include "../include/nsuv-inl.h"
+#include "./catch.hpp"
+#include "./helpers.h"
+
+#include <atomic>
+
+using nsuv::ns_thread;
+using nsuv::ns_async;
+using nsuv::ns_mutex;
+using nsuv::ns_prepare;
+
+struct resources {
+  ns_thread* thread;
+  ns_async* async;
+  ns_mutex* mutex;
+  ns_prepare* prepare;
+};
+
+static std::atomic<int> async_cb_called;
+static int prepare_cb_called;
+static int close_cb_called;
+
+
+static void thread_cb(ns_thread*, std::weak_ptr<resources> wp) {
+  auto res = wp.lock();
+  ASSERT(res);
+  for (;;) {
+    res->mutex->lock();
+    res->mutex->unlock();
+    if (async_cb_called == 3) {
+      break;
+    }
+    CHECK(0 == res->async->send());
+    uv_sleep(0);
+  }
+}
+
+
+template <class H_T>
+static void close_cb(H_T* handle) {
+  CHECK(handle != nullptr);
+  close_cb_called++;
+}
+
+
+static void async_cb(ns_async* handle, std::weak_ptr<resources> wp) {
+  auto res = wp.lock();
+  ASSERT(res);
+  CHECK(handle == res->async);
+  res->mutex->lock();
+  res->mutex->unlock();
+  if (++async_cb_called == 3) {
+    res->async->close(close_cb);
+    res->prepare->close(close_cb);
+  }
+}
+
+
+static void prepare_cb(ns_prepare* handle, std::weak_ptr<resources> wp) {
+  auto res = wp.lock();
+  ASSERT(res);
+  if (prepare_cb_called++)
+    return;
+  CHECK(handle == res->prepare);
+  CHECK(0 == res->thread->create(thread_cb, wp));
+  res->mutex->unlock();
+}
+
+
+TEST_CASE("async_operations_wp", "[async]") {
+  ns_thread thread;
+  ns_async async;
+  ns_mutex mutex;
+  ns_prepare prepare;
+  std::shared_ptr<resources> sp(
+      new resources{ &thread, &async, &mutex, &prepare });
+  std::weak_ptr<resources> res = sp;
+
+  ASSERT_EQ(0, prepare.init(uv_default_loop()));
+  ASSERT_EQ(0, prepare.start(prepare_cb, res));
+  ASSERT_EQ(0, async.init(uv_default_loop(), async_cb, res));
+  ASSERT_EQ(0, mutex.init());
+
+  mutex.lock();
+
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_LT(0, prepare_cb_called);
+  ASSERT_EQ(3, async_cb_called);
+  ASSERT_EQ(2, close_cb_called);
+  ASSERT_EQ(0, thread.join());
+
+  make_valgrind_happy();
+}

--- a/test/test-fs-wp.cc
+++ b/test/test-fs-wp.cc
@@ -1,0 +1,2386 @@
+#include "../include/nsuv-inl.h"
+#include "./helpers.h"
+
+#include <errno.h>
+#include <string.h> /* memset */
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <limits.h> /* INT_MAX, PATH_MAX, IOV_MAX */
+
+#ifndef _WIN32
+# include <unistd.h> /* unlink, rmdir, etc. */
+# define w_unlink unlink
+# define w_rmdir rmdir
+# define w_open open
+# define w_write write
+# define w_close close
+# define w_stricmp stricmp
+# define w_strnicmp strnicmp
+# define w_lseek lseek
+# define w_stat stat
+#else
+# include <winioctl.h>
+# include <direct.h>
+# include <io.h>
+# ifndef ERROR_SYMLINK_NOT_SUPPORTED
+#  define ERROR_SYMLINK_NOT_SUPPORTED 1464
+# endif
+# define w_unlink _unlink
+# define w_rmdir _rmdir
+# define w_open _open
+# define w_write _write
+# define w_close _close
+# define w_stricmp _stricmp
+# define w_strnicmp _strnicmp
+# define w_lseek _lseek
+# define w_stat _stati64
+# define stricmp _stricmp
+# define strnicmp _strnicmp
+# ifndef S_IWUSR
+#   define S_IWUSR 0200
+# endif
+# ifndef S_IRUSR
+#   define S_IRUSR 0400
+# endif
+#endif
+
+#define TOO_LONG_NAME_LENGTH 65536
+#define PATHMAX 4096
+
+using nsuv::ns_fs;
+
+typedef struct {
+  const char* path;
+  double atime;
+  double mtime;
+} utime_check_t;
+
+
+static int dummy_cb_count;
+static int close_cb_count;
+static int create_cb_count;
+static int open_cb_count;
+static int read_cb_count;
+static int write_cb_count;
+static int unlink_cb_count;
+static int mkdir_cb_count;
+static int mkdtemp_cb_count;
+static int mkstemp_cb_count;
+static int rmdir_cb_count;
+static int scandir_cb_count;
+static int stat_cb_count;
+static int rename_cb_count;
+static int fsync_cb_count;
+static int fdatasync_cb_count;
+static int ftruncate_cb_count;
+static int sendfile_cb_count;
+static int fstat_cb_count;
+static int access_cb_count;
+static int chmod_cb_count;
+static int fchmod_cb_count;
+static int chown_cb_count;
+static int fchown_cb_count;
+static int lchown_cb_count;
+static int link_cb_count;
+static int symlink_cb_count;
+static int readlink_cb_count;
+static int realpath_cb_count;
+static int utime_cb_count;
+static int futime_cb_count;
+static int lutime_cb_count;
+static int statfs_cb_count;
+
+static char buf[32];
+static char test_buf[] = "test-buffer\n";
+static uv_buf_t iov;
+
+static void check_permission(const char* filename, unsigned int mode) {
+  int r;
+  uv_fs_t req;
+  uv_stat_t* s;
+
+  r = uv_fs_stat(nullptr, &req, filename, nullptr);
+  ASSERT(r == 0);
+  ASSERT(req.result == 0);
+
+  s = &req.statbuf;
+#if defined(_WIN32) || defined(__CYGWIN__) || defined(__MSYS__)
+  /*
+   * On Windows, chmod can only modify S_IWUSR (_S_IWRITE) bit,
+   * so only testing for the specified flags.
+   */
+  ASSERT((s->st_mode & 0777) & mode);
+#else
+  ASSERT((s->st_mode & 0777) == mode);
+#endif
+
+  uv_fs_req_cleanup(&req);
+}
+
+static void unlink_cb(ns_fs* req, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  ASSERT(req->fs_type == UV_FS_UNLINK);
+  ASSERT(req->result == 0);
+  unlink_cb_count++;
+  req->cleanup();
+}
+
+static void unlink_cb2(ns_fs* req, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  ASSERT(req->fs_type == UV_FS_UNLINK);
+  ASSERT(req->result == 0);
+  unlink_cb_count++;
+  req->cleanup();
+  delete req;
+}
+
+
+static void close_cb(ns_fs* req, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  int r;
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  ASSERT(req->fs_type == UV_FS_CLOSE);
+  ASSERT(req->result == 0);
+  close_cb_count++;
+  req->cleanup();
+  if (close_cb_count == 3) {
+    ns_fs* unlink_req = new (std::nothrow) ns_fs();
+    r = unlink_req->unlink(req->get_loop(), "test_file2", unlink_cb2, d);
+    ASSERT(r == 0);
+  }
+  delete req;
+}
+
+
+static void mkdir_cb(ns_fs* req, std::weak_ptr<ns_fs> wp) {
+  auto mkdir_req = wp.lock();
+  ASSERT(req == mkdir_req.get());
+  ASSERT(req->fs_type == UV_FS_MKDIR);
+  ASSERT(req->result == 0);
+  mkdir_cb_count++;
+  ASSERT(req->path);
+  ASSERT(memcmp(req->path, "test_dir\0", 9) == 0);
+  req->cleanup();
+}
+
+
+static void assert_is_file_type(uv_dirent_t dent) {
+#ifdef HAVE_DIRENT_TYPES
+  /*
+   * For Apple and Windows, we know getdents is expected to work but for other
+   * environments, the filesystem dictates whether or not getdents supports
+   * returning the file type.
+   *
+   *   See:
+   *     http://man7.org/linux/man-pages/man2/getdents.2.html
+   *     https://github.com/libuv/libuv/issues/501
+   */
+  #if defined(__APPLE__) || defined(_WIN32)
+    ASSERT(dent.type == UV_DIRENT_FILE);
+  #else
+    ASSERT((dent.type == UV_DIRENT_FILE || dent.type == UV_DIRENT_UNKNOWN));
+  #endif
+#else
+  ASSERT(dent.type == UV_DIRENT_UNKNOWN);
+#endif
+}
+
+
+static void open_noent_cb(ns_fs* req, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  ASSERT(req->fs_type == UV_FS_OPEN);
+  ASSERT(req->result == UV_ENOENT);
+  open_cb_count++;
+  req->cleanup();
+}
+
+
+TEST_CASE("fs_file_noent_wp", "[fs]") {
+  std::shared_ptr<size_t> sp = std::make_shared<size_t>(42);
+  ns_fs req;
+  uv_loop_t* loop;
+  int r;
+
+  open_cb_count = 0;
+  loop = uv_default_loop();
+
+  r = req.open(loop, "does_not_exist", O_RDONLY, 0, open_noent_cb, TO_WEAK(sp));
+  ASSERT(r == 0);
+
+  ASSERT(open_cb_count == 0);
+  uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT(open_cb_count == 1);
+
+  /* TODO add EACCES test */
+
+  make_valgrind_happy();
+}
+
+
+static void open_nametoolong_cb(ns_fs* req, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  ASSERT(req->fs_type == UV_FS_OPEN);
+  ASSERT(req->result == UV_ENAMETOOLONG);
+  open_cb_count++;
+  req->cleanup();
+}
+
+TEST_CASE("fs_file_nametoolong_wp", "[fs]") {
+  std::shared_ptr<size_t> sp = std::make_shared<size_t>(42);
+  ns_fs req;
+  uv_loop_t* loop;
+  int r;
+  char name[TOO_LONG_NAME_LENGTH + 1];
+
+  loop = uv_default_loop();
+  open_cb_count = 0;
+
+  memset(name, 'a', TOO_LONG_NAME_LENGTH);
+  name[TOO_LONG_NAME_LENGTH] = 0;
+
+  r = req.open(loop, name, O_RDONLY, 0, open_nametoolong_cb, TO_WEAK(sp));
+  ASSERT(r == 0);
+
+  ASSERT(open_cb_count == 0);
+  uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT(open_cb_count == 1);
+
+  make_valgrind_happy();
+}
+
+
+static void open_loop_cb(ns_fs* req, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  ASSERT(req->fs_type == UV_FS_OPEN);
+  ASSERT(req->result == UV_ELOOP);
+  open_cb_count++;
+  req->cleanup();
+}
+
+TEST_CASE("fs_file_loop_wp", "[fs]") {
+  std::shared_ptr<size_t> sp = std::make_shared<size_t>(42);
+  ns_fs req;
+  uv_loop_t* loop;
+  int r;
+
+  loop = uv_default_loop();
+  open_cb_count = 0;
+
+  w_unlink("test_symlink");
+  r = req.symlink("test_symlink", "test_symlink", 0);
+#ifdef _WIN32
+  /*
+   * Symlinks are only suported but only when elevated, otherwise
+   * we'll see UV_EPERM.
+   */
+  if (r == UV_EPERM)
+    return;
+#elif defined(__MSYS__)
+  /* MSYS2's approximation of symlinks with copies does not work for broken
+     links.  */
+  if (r == UV_ENOENT)
+    return;
+#endif
+  ASSERT(r == 0);
+  req.cleanup();
+
+  r = req.open("test_symlink", O_RDONLY, 0);
+  ASSERT(r == UV_ELOOP);
+  ASSERT(req.result == UV_ELOOP);
+  req.cleanup();
+
+  r = req.open(loop, "test_symlink", O_RDONLY, 0, open_loop_cb, TO_WEAK(sp));
+  ASSERT(r == 0);
+
+  ASSERT(open_cb_count == 0);
+  uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT(open_cb_count == 1);
+
+  w_unlink("test_symlink");
+
+  make_valgrind_happy();
+}
+
+static void check_utime(const char* path,
+                        double atime,
+                        double mtime,
+                        int test_lutime) {
+  uv_stat_t* s;
+  ns_fs req;
+  int r;
+
+  if (test_lutime)
+    r = req.lstat(path);
+  else
+    r = req.stat(path);
+
+  ASSERT_EQ(r, 0);
+
+  ASSERT_EQ(req.result, 0);
+  s = &req.statbuf;
+
+  if (s->st_atim.tv_nsec == 0 && s->st_mtim.tv_nsec == 0) {
+    /*
+     * Test sub-second timestamps only when supported (such as Windows with
+     * NTFS). Some other platforms support sub-second timestamps, but that
+     * support is filesystem-dependent. Notably OS X (HFS Plus) does NOT
+     * support sub-second timestamps. But kernels may round or truncate in
+     * either direction, so we may accept either possible answer.
+     */
+#ifdef _WIN32
+    ASSERT_DOUBLE_EQ(atime, static_cast<uint32_t>(atime));
+    ASSERT_DOUBLE_EQ(mtime, static_cast<uint32_t>(atime));
+#endif
+    if (atime > 0 || static_cast<uint32_t>(atime) == atime)
+      ASSERT_EQ(s->st_atim.tv_sec, static_cast<uint32_t>(atime));
+    if (mtime > 0 || static_cast<uint32_t>(mtime) == mtime)
+      ASSERT_EQ(s->st_mtim.tv_sec, static_cast<uint32_t>(mtime));
+    ASSERT_GE(s->st_atim.tv_sec, static_cast<uint32_t>(atime) - 1);
+    ASSERT_GE(s->st_mtim.tv_sec, static_cast<uint32_t>(mtime) - 1);
+    ASSERT_LE(s->st_atim.tv_sec, static_cast<uint32_t>(atime));
+    ASSERT_LE(s->st_mtim.tv_sec, static_cast<uint32_t>(mtime));
+  } else {
+    double st_atim;
+    double st_mtim;
+#if !defined(__APPLE__) && !defined(__SUNPRO_C)
+    /* TODO(vtjnash): would it be better to normalize this? */
+    ASSERT_DOUBLE_GE(s->st_atim.tv_nsec, 0);
+    ASSERT_DOUBLE_GE(s->st_mtim.tv_nsec, 0);
+#endif
+    st_atim = s->st_atim.tv_sec + s->st_atim.tv_nsec / 1e9;
+    st_mtim = s->st_mtim.tv_sec + s->st_mtim.tv_nsec / 1e9;
+    /*
+     * Linux does not allow reading reliably the atime of a symlink
+     * since readlink() can update it
+     */
+    if (!test_lutime)
+      ASSERT_DOUBLE_EQ(st_atim, atime);
+    ASSERT_DOUBLE_EQ(st_mtim, mtime);
+  }
+
+  req.cleanup();
+}
+
+
+static void fsync_cb(ns_fs* req, std::weak_ptr<size_t> d) {
+  ns_fs* close_req = new (std::nothrow) ns_fs();
+  ns_fs* open_req1 = req->get_data<ns_fs>();
+  auto sp = d.lock();
+  int r;
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  ASSERT_NOT_NULL(open_req1);
+  ASSERT_NE(nullptr, close_req);
+  ASSERT(req->fs_type == UV_FS_FSYNC);
+  ASSERT(req->result == 0);
+  fsync_cb_count++;
+  req->cleanup();
+  r = close_req->close(req->get_loop(), open_req1->result, close_cb, d);
+  ASSERT(r == 0);
+  delete req;
+}
+
+static void fdatasync_cb(ns_fs* req, std::weak_ptr<size_t> d) {
+  ns_fs* fsync_req = new (std::nothrow) ns_fs();
+  ns_fs* open_req1 = req->get_data<ns_fs>();
+  auto sp = d.lock();
+  int r;
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  ASSERT_NOT_NULL(open_req1);
+  ASSERT(req->fs_type == UV_FS_FDATASYNC);
+  ASSERT(req->result == 0);
+  fdatasync_cb_count++;
+  req->cleanup();
+  fsync_req->set_data(open_req1);
+  r = fsync_req->fsync(req->get_loop(), open_req1->result, fsync_cb, d);
+  ASSERT(r == 0);
+  delete req;
+}
+
+static void write_cb(ns_fs* req, std::weak_ptr<size_t> d) {
+  ns_fs* fdatasync_req = new (std::nothrow) ns_fs;
+  ns_fs* open_req1 = req->get_data<ns_fs>();
+  auto sp = d.lock();
+  int r;
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  ASSERT_NOT_NULL(open_req1);
+  ASSERT_NE(nullptr, fdatasync_req);
+  ASSERT(req->fs_type == UV_FS_WRITE);
+  ASSERT(req->result >= 0);  /* FIXME(bnoordhuis) Check if requested size? */
+  write_cb_count++;
+  req->cleanup();
+  fdatasync_req->set_data(open_req1);
+  r = fdatasync_req->fdatasync(
+      req->get_loop(), open_req1->result, fdatasync_cb, d);
+  ASSERT(r == 0);
+  delete req;
+}
+
+static void create_cb(ns_fs* req, std::weak_ptr<size_t> d) {
+  ns_fs* write_req = new (std::nothrow) ns_fs();
+  auto sp = d.lock();
+  int r;
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  ASSERT_NE(nullptr, write_req);
+  ASSERT(req->fs_type == UV_FS_OPEN);
+  ASSERT(req->result >= 0);
+  create_cb_count++;
+  req->cleanup();
+  iov = uv_buf_init(test_buf, sizeof(test_buf));
+  write_req->set_data(req);
+  r = write_req->write(
+      req->get_loop(), req->result, { iov }, -1, write_cb, d);
+  ASSERT(r == 0);
+}
+
+static void ftruncate_cb(ns_fs* req, std::weak_ptr<size_t> d) {
+  ns_fs* close_req = new (std::nothrow) ns_fs();
+  ns_fs* open_req1 = req->get_data<ns_fs>();
+  auto sp = d.lock();
+  int r;
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  ASSERT_NOT_NULL(open_req1);
+  ASSERT_NE(nullptr, close_req);
+  ASSERT(req->fs_type == UV_FS_FTRUNCATE);
+  ASSERT(req->result == 0);
+  ftruncate_cb_count++;
+  req->cleanup();
+  r = close_req->close(req->get_loop(), open_req1->result, close_cb, d);
+  ASSERT(r == 0);
+  delete req;
+}
+
+static void read_cb(ns_fs* req, std::weak_ptr<size_t> d) {
+  ns_fs* rreq = new (std::nothrow) ns_fs();
+  ns_fs* open_req1 = req->get_data<ns_fs>();
+  auto sp = d.lock();
+  int r;
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  ASSERT_NOT_NULL(open_req1);
+  ASSERT_NE(nullptr, rreq);
+  ASSERT(req->fs_type == UV_FS_READ);
+  ASSERT(req->result >= 0);  /* FIXME(bnoordhuis) Check if requested size? */
+  read_cb_count++;
+  req->cleanup();
+  rreq->set_data(open_req1);
+  if (read_cb_count == 1) {
+    r = rreq->ftruncate(req->get_loop(), open_req1->result, 7, ftruncate_cb, d);
+  } else {
+    r = rreq->close(req->get_loop(), open_req1->result, close_cb, d);
+  }
+  ASSERT(r == 0);
+  delete req;
+}
+
+static void open_cb(ns_fs* open_req1, std::weak_ptr<size_t> d) {
+  ns_fs* read_req = new (std::nothrow) ns_fs();
+  auto sp = d.lock();
+  int r;
+  uv_buf_t iov;
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  ASSERT_NE(nullptr, read_req);
+  ASSERT(open_req1->fs_type == UV_FS_OPEN);
+  if (open_req1->result < 0) {
+    fprintf(
+        stderr, "async open error: %d\n", static_cast<int>(open_req1->result));
+    FAIL("error");
+  }
+  open_cb_count++;
+  ASSERT(open_req1->path);
+  ASSERT(memcmp(open_req1->path, "test_file2\0", 11) == 0);
+  open_req1->cleanup();
+  read_req->set_data(open_req1);
+  memset(buf, 0, sizeof(buf));
+  iov = uv_buf_init(buf, sizeof(buf));
+  r = read_req->read(open_req1->get_loop(),
+                     open_req1->result,
+                     { iov },
+                     -1,
+                     read_cb,
+                     d);
+  ASSERT(r == 0);
+}
+
+static void rename_cb(ns_fs* req, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  ASSERT(req->fs_type == UV_FS_RENAME);
+  ASSERT(req->result == 0);
+  rename_cb_count++;
+  req->cleanup();
+}
+
+TEST_CASE("fs_file_async_wp", "[fs]") {
+  std::shared_ptr<size_t> sp = std::make_shared<size_t>(42);
+  ns_fs open_req1;
+  ns_fs rename_req;
+  uv_loop_t* loop;
+  int r;
+
+  /* Setup. */
+  w_unlink("test_file");
+  w_unlink("test_file2");
+
+  loop = uv_default_loop();
+  create_cb_count = 0;
+  write_cb_count = 0;
+  fsync_cb_count = 0;
+  fdatasync_cb_count = 0;
+  close_cb_count = 0;
+  open_cb_count = 0;
+
+  r = open_req1.open(loop,
+                     "test_file",
+                     O_WRONLY | O_CREAT,
+                     S_IRUSR | S_IWUSR,
+                     create_cb,
+                     TO_WEAK(sp));
+  ASSERT(r == 0);
+  uv_run(loop, UV_RUN_DEFAULT);
+
+  ASSERT(create_cb_count == 1);
+  ASSERT(write_cb_count == 1);
+  ASSERT(fsync_cb_count == 1);
+  ASSERT(fdatasync_cb_count == 1);
+  ASSERT(close_cb_count == 1);
+
+  r = rename_req.rename(
+      loop, "test_file", "test_file2", rename_cb, TO_WEAK(sp));
+  ASSERT(r == 0);
+
+  uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT(create_cb_count == 1);
+  ASSERT(write_cb_count == 1);
+  ASSERT(close_cb_count == 1);
+  ASSERT(rename_cb_count == 1);
+
+  r = open_req1.open(loop, "test_file2", O_RDWR, 0, open_cb, TO_WEAK(sp));
+  ASSERT(r == 0);
+
+  uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT(open_cb_count == 1);
+  ASSERT(read_cb_count == 1);
+  ASSERT(close_cb_count == 2);
+  ASSERT(rename_cb_count == 1);
+  ASSERT(create_cb_count == 1);
+  ASSERT(write_cb_count == 1);
+  ASSERT(ftruncate_cb_count == 1);
+
+  r = open_req1.open(loop, "test_file2", O_RDONLY, 0, open_cb, TO_WEAK(sp));
+  ASSERT(r == 0);
+
+  uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT(open_cb_count == 2);
+  ASSERT(read_cb_count == 2);
+  ASSERT(close_cb_count == 3);
+  ASSERT(rename_cb_count == 1);
+  ASSERT(unlink_cb_count == 1);
+  ASSERT(create_cb_count == 1);
+  ASSERT(write_cb_count == 1);
+  ASSERT(ftruncate_cb_count == 1);
+
+  /* Cleanup. */
+  w_unlink("test_file");
+  w_unlink("test_file2");
+
+  make_valgrind_happy();
+}
+
+
+static void scandir_cb(ns_fs* req, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  uv_dirent_t dent;
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  ASSERT(req->fs_type == UV_FS_SCANDIR);
+  ASSERT(req->result == 2);
+  ASSERT(req->ptr);
+
+  while (UV_EOF != req->scandir_next(&dent)) {
+    assert_is_file_type(dent);
+  }
+  scandir_cb_count++;
+  ASSERT(req->path);
+  ASSERT(memcmp(req->path, "test_dir\0", 9) == 0);
+  req->cleanup();
+  ASSERT(!req->ptr);
+}
+
+
+static void stat_cb(ns_fs* req, std::weak_ptr<ns_fs> wp) {
+  auto stat_req = wp.lock();
+  ASSERT(stat_req);
+  ASSERT(req == stat_req.get());
+  ASSERT((req->fs_type == UV_FS_STAT || req->fs_type == UV_FS_LSTAT));
+  ASSERT(req->result == 0);
+  ASSERT(req->ptr);
+  stat_cb_count++;
+  req->cleanup();
+  ASSERT(!req->ptr);
+}
+
+static void rmdir_cb(ns_fs* req, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  ASSERT(req->fs_type == UV_FS_RMDIR);
+  ASSERT(req->result == 0);
+  rmdir_cb_count++;
+  ASSERT(req->path);
+  ASSERT(memcmp(req->path, "test_dir\0", 9) == 0);
+  req->cleanup();
+}
+
+TEST_CASE("fs_async_dir_wp", "[fs]") {
+  std::shared_ptr<size_t> sp = std::make_shared<size_t>(42);
+  int r;
+  auto mkdir_req = std::make_shared<ns_fs>();
+  auto stat_req = std::make_shared<ns_fs>();
+  uv_dirent_t dent;
+  ns_fs close_req;
+  ns_fs open_req1;
+  ns_fs rmdir_req;
+  ns_fs scandir_req;
+  ns_fs unlink_req;
+  uv_loop_t* loop;
+
+  /* Setup */
+  w_unlink("test_dir/file1");
+  w_unlink("test_dir/file2");
+  w_rmdir("test_dir");
+
+  loop = uv_default_loop();
+  mkdir_cb_count = 0;
+  scandir_cb_count = 0;
+  stat_cb_count = 0;
+  unlink_cb_count = 0;
+  rmdir_cb_count = 0;
+
+  r = mkdir_req->mkdir(loop, "test_dir", 0755, mkdir_cb, TO_WEAK(mkdir_req));
+  ASSERT(r == 0);
+
+  uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT(mkdir_cb_count == 1);
+
+  /* Create 2 files synchronously. */
+  r = open_req1.open("test_dir/file1", O_WRONLY | O_CREAT, S_IWUSR | S_IRUSR);
+  ASSERT(r >= 0);
+  open_req1.cleanup();
+  r = close_req.close(open_req1.result);
+  ASSERT(r == 0);
+  close_req.cleanup();
+
+  r = open_req1.open("test_dir/file2", O_WRONLY | O_CREAT, S_IWUSR | S_IRUSR);
+  ASSERT(r >= 0);
+  open_req1.cleanup();
+  r = close_req.close(open_req1.result);
+  ASSERT(r == 0);
+  close_req.cleanup();
+
+  r = scandir_req.scandir(loop, "test_dir", 0, scandir_cb, TO_WEAK(sp));
+  ASSERT(r == 0);
+
+  uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT(scandir_cb_count == 1);
+
+  /* sync uv_fs_scandir */
+  r = scandir_req.scandir("test_dir", 0);
+  ASSERT(r == 2);
+  ASSERT(scandir_req.result == 2);
+  ASSERT(scandir_req.ptr);
+  while (UV_EOF != scandir_req.scandir_next(&dent)) {
+    assert_is_file_type(dent);
+  }
+  scandir_req.cleanup();
+  ASSERT(!scandir_req.ptr);
+
+  r = stat_req->stat(loop, "test_dir", stat_cb, TO_WEAK(stat_req));
+  ASSERT(r == 0);
+  uv_run(loop, UV_RUN_DEFAULT);
+
+  r = stat_req->stat(loop, "test_dir/", stat_cb, TO_WEAK(stat_req));
+  ASSERT(r == 0);
+  uv_run(loop, UV_RUN_DEFAULT);
+
+  r = stat_req->lstat(loop, "test_dir", stat_cb, TO_WEAK(stat_req));
+  ASSERT(r == 0);
+  uv_run(loop, UV_RUN_DEFAULT);
+
+  r = stat_req->lstat(loop, "test_dir/", stat_cb, TO_WEAK(stat_req));
+  ASSERT(r == 0);
+  uv_run(loop, UV_RUN_DEFAULT);
+
+  ASSERT(stat_cb_count == 4);
+
+  r = unlink_req.unlink(loop, "test_dir/file1", unlink_cb, TO_WEAK(sp));
+  ASSERT(r == 0);
+  uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT(unlink_cb_count == 1);
+
+  r = unlink_req.unlink(loop, "test_dir/file2", unlink_cb, TO_WEAK(sp));
+  ASSERT(r == 0);
+  uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT(unlink_cb_count == 2);
+
+  r = rmdir_req.rmdir(loop, "test_dir", rmdir_cb, TO_WEAK(sp));
+  ASSERT(r == 0);
+  uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT(rmdir_cb_count == 1);
+
+  /* Cleanup */
+  w_unlink("test_dir/file1");
+  w_unlink("test_dir/file2");
+  w_rmdir("test_dir");
+
+  make_valgrind_happy();
+}
+
+
+static void sendfile_cb(ns_fs* req, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  ASSERT(req->fs_type == UV_FS_SENDFILE);
+  ASSERT(req->result == 65545);
+  sendfile_cb_count++;
+  req->cleanup();
+}
+
+static void sendfile_nodata_cb(ns_fs* req, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  ASSERT(req->fs_type == UV_FS_SENDFILE);
+  ASSERT(req->result == 0);
+  sendfile_cb_count++;
+  req->cleanup();
+}
+
+static void test_sendfile(void (*setup)(int),
+                          ns_fs::ns_fs_cb_wp<size_t> cb,
+                          off_t expected_size) {
+  std::shared_ptr<size_t> sp = std::make_shared<size_t>(42);
+  int f, r;
+#ifndef _WIN32
+  struct stat s1, s2;
+#else
+  struct _stat64 s1, s2;
+#endif
+  ns_fs close_req;
+  ns_fs open_req1;
+  ns_fs open_req2;
+  ns_fs req;
+  ns_fs sendfile_req;
+  uv_loop_t* loop;
+  char buf1[1];
+
+  loop = uv_default_loop();
+  sendfile_cb_count = 0;
+
+  /* Setup. */
+  w_unlink("test_file");
+  w_unlink("test_file2");
+
+  f = w_open("test_file", O_WRONLY | O_CREAT, S_IWUSR | S_IRUSR);
+  ASSERT(f != -1);
+
+  if (setup != nullptr)
+    setup(f);
+
+  r = w_close(f);
+  ASSERT(r == 0);
+
+  /* Test starts here. */
+  r = open_req1.open("test_file", O_RDWR, 0);
+  ASSERT(r >= 0);
+  ASSERT(open_req1.result >= 0);
+  open_req1.cleanup();
+
+  r = open_req2.open("test_file2", O_WRONLY | O_CREAT, S_IWUSR | S_IRUSR);
+  ASSERT(r >= 0);
+  ASSERT(open_req2.result >= 0);
+  open_req2.cleanup();
+
+  r = sendfile_req.sendfile(
+      loop, open_req2.result, open_req1.result, 1, 131072, cb, TO_WEAK(sp));
+  ASSERT(r == 0);
+  uv_run(loop, UV_RUN_DEFAULT);
+
+  ASSERT(sendfile_cb_count == 1);
+
+  r = close_req.close(open_req1.result);
+  ASSERT(r == 0);
+  close_req.cleanup();
+  r = close_req.close(open_req2.result);
+  ASSERT(r == 0);
+  close_req.cleanup();
+
+  memset(&s1, 0, sizeof(s1));
+  memset(&s2, 0, sizeof(s2));
+  ASSERT(0 == w_stat("test_file", &s1));
+  ASSERT(0 == w_stat("test_file2", &s2));
+  ASSERT(s2.st_size == expected_size);
+
+  if (expected_size > 0) {
+    ASSERT_UINT64_EQ(s1.st_size, s2.st_size + 1);
+    r = open_req1.open("test_file2", O_RDWR, 0);
+    ASSERT(r >= 0);
+    ASSERT(open_req1.result >= 0);
+    open_req1.cleanup();
+
+    memset(buf1, 0, sizeof(buf1));
+    iov = uv_buf_init(buf1, sizeof(buf1));
+    r = req.read(open_req1.result, { iov }, -1);
+    ASSERT(r >= 0);
+    ASSERT(req.result >= 0);
+    ASSERT_EQ(buf1[0], 'e'); /* 'e' from begin */
+    req.cleanup();
+  } else {
+    ASSERT_UINT64_EQ(s1.st_size, s2.st_size);
+  }
+
+  /* Cleanup. */
+  w_unlink("test_file");
+  w_unlink("test_file2");
+
+  make_valgrind_happy();
+}
+
+static void sendfile_setup(int f) {
+  ASSERT(6 == w_write(f, "begin\n", 6));
+  ASSERT(65542 == w_lseek(f, 65536, SEEK_CUR));
+  ASSERT(4 == w_write(f, "end\n", 4));
+}
+
+TEST_CASE("fs_async_sendfile_wp", "[fs]") {
+  test_sendfile(sendfile_setup, sendfile_cb, 65545);
+}
+
+TEST_CASE("fs_async_sendfile_nodata_wp", "[fs]") {
+  test_sendfile(nullptr, sendfile_nodata_cb, 0);
+}
+
+
+static void check_mkdtemp_result(ns_fs* req) {
+  ns_fs stat_req;
+  int r;
+
+  ASSERT(req->fs_type == UV_FS_MKDTEMP);
+  ASSERT(req->result == 0);
+  ASSERT(req->path);
+  ASSERT(strlen(req->path) == 15);
+  ASSERT(memcmp(req->path, "test_dir_", 9) == 0);
+  ASSERT(memcmp(req->path + 9, "XXXXXX", 6) != 0);
+  check_permission(req->path, 0700);
+
+  /* Check if req->path is actually a directory */
+  r = stat_req.stat(req->path);
+  ASSERT(r == 0);
+  ASSERT(static_cast<uv_stat_t*>(stat_req.ptr)->st_mode & S_IFDIR);
+  stat_req.cleanup();
+}
+
+static void mkdtemp_cb(ns_fs* req, std::weak_ptr<ns_fs> wp) {
+  auto mkdtemp_req1 = wp.lock();
+  ASSERT(mkdtemp_req1);
+  ASSERT(req == mkdtemp_req1.get());
+  check_mkdtemp_result(req);
+  mkdtemp_cb_count++;
+}
+
+TEST_CASE("fs_mkdtemp_wp", "[fs]") {
+  int r;
+  const char* path_template = "test_dir_XXXXXX";
+  auto mkdtemp_req1 = std::make_shared<ns_fs>();
+  uv_loop_t* loop;
+
+  loop = uv_default_loop();
+  mkdtemp_cb_count = 0;
+
+  r = mkdtemp_req1->mkdtemp(
+      loop, path_template, mkdtemp_cb, TO_WEAK(mkdtemp_req1));
+  ASSERT(r == 0);
+
+  uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT(mkdtemp_cb_count == 1);
+
+  /* Cleanup */
+  w_rmdir(mkdtemp_req1->path);
+  mkdtemp_req1->cleanup();
+
+  make_valgrind_happy();
+}
+
+
+static void check_mkstemp_result(ns_fs* req) {
+  ns_fs stat_req;
+  int r;
+
+  ASSERT(req->fs_type == UV_FS_MKSTEMP);
+  ASSERT(req->result >= 0);
+  ASSERT(req->path);
+  ASSERT(strlen(req->path) == 16);
+  ASSERT(memcmp(req->path, "test_file_", 10) == 0);
+  ASSERT(memcmp(req->path + 10, "XXXXXX", 6) != 0);
+  check_permission(req->path, 0600);
+
+  /* Check if req->path is actually a file */
+  r = stat_req.stat(req->path);
+  ASSERT(r == 0);
+  ASSERT(stat_req.statbuf.st_mode & S_IFREG);
+  stat_req.cleanup();
+}
+
+
+static void mkstemp_cb(ns_fs* req, std::weak_ptr<ns_fs> wp) {
+  auto mkstemp_req = wp.lock();
+  ASSERT(mkstemp_req);
+  ASSERT(req == mkstemp_req.get());
+  check_mkstemp_result(req);
+  mkstemp_cb_count++;
+}
+
+TEST_CASE("fs_mkstemp_wp", "[fs]") {
+  int r;
+  int fd;
+  const char path_template[] = "test_file_XXXXXX";
+  auto mkstemp_req1 = std::make_shared<ns_fs>();
+  ns_fs req;
+  uv_loop_t* loop;
+
+  loop = uv_default_loop();
+  mkstemp_cb_count = 0;
+
+  r = mkstemp_req1->mkstemp(
+      loop, path_template, mkstemp_cb, TO_WEAK(mkstemp_req1));
+  ASSERT(r == 0);
+
+  uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT(mkstemp_cb_count == 1);
+
+  /* We can write to the opened file */
+  iov = uv_buf_init(test_buf, sizeof(test_buf));
+  r = req.write(mkstemp_req1->result, { iov }, -1);
+  ASSERT(r == sizeof(test_buf));
+  ASSERT(req.result == sizeof(test_buf));
+  req.cleanup();
+
+  /* Cleanup */
+  r = req.close(mkstemp_req1->result);
+  req.cleanup();
+
+  fd = req.open(mkstemp_req1->path, O_RDONLY, 0);
+  ASSERT(fd >= 0);
+  req.cleanup();
+
+  memset(buf, 0, sizeof(buf));
+  iov = uv_buf_init(buf, sizeof(buf));
+  r = req.read(fd, { iov }, -1);
+  ASSERT(r >= 0);
+  ASSERT(req.result >= 0);
+  req.cleanup();
+
+  r = req.close(fd);
+  req.cleanup();
+
+  w_unlink(mkstemp_req1->path);
+  mkstemp_req1->cleanup();
+
+  make_valgrind_happy();
+}
+
+
+static void fstat_cb(ns_fs* req, std::weak_ptr<size_t> d) {
+  uv_stat_t* s = static_cast<uv_stat_t*>(req->ptr);
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  ASSERT(req->fs_type == UV_FS_FSTAT);
+  ASSERT(req->result == 0);
+  ASSERT(s->st_size == sizeof(test_buf));
+  req->cleanup();
+  fstat_cb_count++;
+}
+
+TEST_CASE("fs_fstat_wp", "[fs]") {
+  std::shared_ptr<size_t> sp = std::make_shared<size_t>(42);
+  int r;
+  ns_fs req;
+  uv_file file;
+  uv_stat_t* s;
+  uv_loop_t* loop;
+#ifndef _WIN32
+  struct stat t;
+#endif
+
+#if defined(__s390__) && defined(__QEMU__)
+  /* qemu-user-s390x has this weird bug where statx() reports nanoseconds
+   * but plain fstat() does not.
+   */
+  RETURN_SKIP("Test does not currently work in QEMU");
+#endif
+
+  /* Setup. */
+  w_unlink("test_file");
+
+  loop = uv_default_loop();
+  fstat_cb_count = 0;
+
+  r = req.open("test_file", O_RDWR | O_CREAT, S_IWUSR | S_IRUSR);
+  ASSERT(r >= 0);
+  ASSERT(req.result >= 0);
+  file = req.result;
+  req.cleanup();
+
+#ifndef _WIN32
+  memset(&t, 0, sizeof(t));
+  ASSERT(0 == fstat(file, &t));
+  ASSERT(0 == req.fstat(file));
+  ASSERT(req.result == 0);
+  s = static_cast<uv_stat_t*>(req.ptr);
+# if defined(__APPLE__)
+  ASSERT(s->st_birthtim.tv_sec == t.st_birthtimespec.tv_sec);
+  ASSERT(s->st_birthtim.tv_nsec == t.st_birthtimespec.tv_nsec);
+# elif defined(__linux__)
+  /* If statx() is supported, the birth time should be equal to the change time
+   * because we just created the file. On older kernels, it's set to zero.
+   */
+  ASSERT((s->st_birthtim.tv_sec == 0 ||
+         s->st_birthtim.tv_sec == t.st_ctim.tv_sec));
+  ASSERT((s->st_birthtim.tv_nsec == 0 ||
+         s->st_birthtim.tv_nsec == t.st_ctim.tv_nsec));
+# endif
+#endif
+
+  iov = uv_buf_init(test_buf, sizeof(test_buf));
+  r = req.write(file, { iov }, -1);
+  ASSERT(r == sizeof(test_buf));
+  ASSERT(req.result == sizeof(test_buf));
+  req.cleanup();
+
+  memset(&req.statbuf, 0xaa, sizeof(req.statbuf));
+  r = req.fstat(file);
+  ASSERT(r == 0);
+  ASSERT(req.result == 0);
+  s = static_cast<uv_stat_t*>(req.ptr);
+  ASSERT(s->st_size == sizeof(test_buf));
+
+#ifndef _WIN32
+  r = fstat(file, &t);
+  ASSERT(r == 0);
+
+  ASSERT(s->st_dev == static_cast<uint64_t>(t.st_dev));
+  ASSERT(s->st_mode == static_cast<uint64_t>(t.st_mode));
+  ASSERT(s->st_nlink == static_cast<uint64_t>(t.st_nlink));
+  ASSERT(s->st_uid == static_cast<uint64_t>(t.st_uid));
+  ASSERT(s->st_gid == static_cast<uint64_t>(t.st_gid));
+  ASSERT(s->st_rdev == static_cast<uint64_t>(t.st_rdev));
+  ASSERT(s->st_ino == static_cast<uint64_t>(t.st_ino));
+  ASSERT(s->st_size == static_cast<uint64_t>(t.st_size));
+  ASSERT(s->st_blksize == static_cast<uint64_t>(t.st_blksize));
+  ASSERT(s->st_blocks == static_cast<uint64_t>(t.st_blocks));
+#if defined(__APPLE__)
+  ASSERT(s->st_atim.tv_sec == t.st_atimespec.tv_sec);
+  ASSERT(s->st_atim.tv_nsec == t.st_atimespec.tv_nsec);
+  ASSERT(s->st_mtim.tv_sec == t.st_mtimespec.tv_sec);
+  ASSERT(s->st_mtim.tv_nsec == t.st_mtimespec.tv_nsec);
+  ASSERT(s->st_ctim.tv_sec == t.st_ctimespec.tv_sec);
+  ASSERT(s->st_ctim.tv_nsec == t.st_ctimespec.tv_nsec);
+#elif defined(_AIX)    || \
+      defined(__MVS__)
+  ASSERT(s->st_atim.tv_sec == t.st_atime);
+  ASSERT(s->st_atim.tv_nsec == 0);
+  ASSERT(s->st_mtim.tv_sec == t.st_mtime);
+  ASSERT(s->st_mtim.tv_nsec == 0);
+  ASSERT(s->st_ctim.tv_sec == t.st_ctime);
+  ASSERT(s->st_ctim.tv_nsec == 0);
+#elif defined(__ANDROID__)
+  ASSERT(s->st_atim.tv_sec == t.st_atime);
+  ASSERT(s->st_atim.tv_nsec == t.st_atimensec);
+  ASSERT(s->st_mtim.tv_sec == t.st_mtime);
+  ASSERT(s->st_mtim.tv_nsec == t.st_mtimensec);
+  ASSERT(s->st_ctim.tv_sec == t.st_ctime);
+  ASSERT(s->st_ctim.tv_nsec == t.st_ctimensec);
+#elif defined(__sun)           || \
+      defined(__DragonFly__)   || \
+      defined(__FreeBSD__)     || \
+      defined(__OpenBSD__)     || \
+      defined(__NetBSD__)      || \
+      defined(_GNU_SOURCE)     || \
+      defined(_BSD_SOURCE)     || \
+      defined(_SVID_SOURCE)    || \
+      defined(_XOPEN_SOURCE)   || \
+      defined(_DEFAULT_SOURCE)
+  ASSERT(s->st_atim.tv_sec == t.st_atim.tv_sec);
+  ASSERT(s->st_atim.tv_nsec == t.st_atim.tv_nsec);
+  ASSERT(s->st_mtim.tv_sec == t.st_mtim.tv_sec);
+  ASSERT(s->st_mtim.tv_nsec == t.st_mtim.tv_nsec);
+  ASSERT(s->st_ctim.tv_sec == t.st_ctim.tv_sec);
+  ASSERT(s->st_ctim.tv_nsec == t.st_ctim.tv_nsec);
+# if defined(__FreeBSD__)    || \
+     defined(__NetBSD__)
+  ASSERT(s->st_birthtim.tv_sec == t.st_birthtim.tv_sec);
+  ASSERT(s->st_birthtim.tv_nsec == t.st_birthtim.tv_nsec);
+# endif
+#else
+  ASSERT(s->st_atim.tv_sec == t.st_atime);
+  ASSERT(s->st_atim.tv_nsec == 0);
+  ASSERT(s->st_mtim.tv_sec == t.st_mtime);
+  ASSERT(s->st_mtim.tv_nsec == 0);
+  ASSERT(s->st_ctim.tv_sec == t.st_ctime);
+  ASSERT(s->st_ctim.tv_nsec == 0);
+#endif
+#endif
+
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__)
+  ASSERT(s->st_flags == t.st_flags);
+  ASSERT(s->st_gen == t.st_gen);
+#else
+  ASSERT(s->st_flags == 0);
+  ASSERT(s->st_gen == 0);
+#endif
+
+  req.cleanup();
+
+  /* Now do the uv_fs_fstat call asynchronously */
+  r = req.fstat(loop, file, fstat_cb, TO_WEAK(sp));
+  ASSERT(r == 0);
+  uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT(fstat_cb_count == 1);
+
+
+  r = req.close(file);
+  ASSERT(r == 0);
+  ASSERT(req.result == 0);
+  req.cleanup();
+
+  /*
+   * Run the loop just to check we don't have make any extraneous uv_ref()
+   * calls. This should drop out immediately.
+   */
+  uv_run(loop, UV_RUN_DEFAULT);
+
+  /* Cleanup. */
+  w_unlink("test_file");
+
+  make_valgrind_happy();
+}
+
+
+static void access_cb(ns_fs* req, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  ASSERT(req->fs_type == UV_FS_ACCESS);
+  access_cb_count++;
+  req->cleanup();
+}
+
+TEST_CASE("fs_access_wp", "[fs]") {
+  std::shared_ptr<size_t> sp = std::make_shared<size_t>(42);
+  int r;
+  ns_fs req;
+  uv_file file;
+  uv_loop_t* loop;
+
+  /* Setup. */
+  w_unlink("test_file");
+  w_rmdir("test_dir");
+
+  loop = uv_default_loop();
+  access_cb_count = 0;
+
+  /* File should not exist */
+  r = req.access("test_file", F_OK);
+  ASSERT(r < 0);
+  ASSERT(req.result < 0);
+  req.cleanup();
+
+  /* File should not exist */
+  r = req.access(loop, "test_file", F_OK, access_cb, TO_WEAK(sp));
+  ASSERT(r == 0);
+  uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT(access_cb_count == 1);
+  access_cb_count = 0; /* reset for the next test */
+
+  /* Create file */
+  r = req.open("test_file", O_RDWR | O_CREAT, S_IWUSR | S_IRUSR);
+  ASSERT(r >= 0);
+  ASSERT(req.result >= 0);
+  file = req.result;
+  req.cleanup();
+
+  /* File should exist */
+  r = req.access("test_file", F_OK);
+  ASSERT(r == 0);
+  ASSERT(req.result == 0);
+  req.cleanup();
+
+  /* File should exist */
+  r = req.access(loop, "test_file", F_OK, access_cb, TO_WEAK(sp));
+  ASSERT(r == 0);
+  uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT(access_cb_count == 1);
+  access_cb_count = 0; /* reset for the next test */
+
+  /* Close file */
+  r = req.close(file);
+  ASSERT(r == 0);
+  ASSERT(req.result == 0);
+  req.cleanup();
+
+  /* Directory access */
+  r = req.mkdir("test_dir", 0777);
+  ASSERT(r == 0);
+  req.cleanup();
+
+  r = req.access("test_dir", W_OK);
+  ASSERT(r == 0);
+  ASSERT(req.result == 0);
+  req.cleanup();
+
+  /*
+   * Run the loop just to check we don't have make any extraneous uv_ref()
+   * calls. This should drop out immediately.
+   */
+  uv_run(loop, UV_RUN_DEFAULT);
+
+  /* Cleanup. */
+  w_unlink("test_file");
+  w_rmdir("test_dir");
+
+  make_valgrind_happy();
+}
+
+
+static void chmod_cb(ns_fs* req, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  ASSERT(req->fs_type == UV_FS_CHMOD);
+  ASSERT(req->result == 0);
+  chmod_cb_count++;
+  req->cleanup();
+  check_permission("test_file", *req->get_data<int>());
+}
+
+static void fchmod_cb(ns_fs* req, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  ASSERT(req->fs_type == UV_FS_FCHMOD);
+  ASSERT(req->result == 0);
+  fchmod_cb_count++;
+  req->cleanup();
+  check_permission("test_file", *req->get_data<int>());
+}
+
+TEST_CASE("fs_chmod_wp", "[fs]") {
+  std::shared_ptr<size_t> sp = std::make_shared<size_t>(42);
+  int r;
+  ns_fs req;
+  uv_file file;
+  uv_loop_t* loop;
+
+  /* Setup. */
+  w_unlink("test_file");
+
+  loop = uv_default_loop();
+  chmod_cb_count = 0;
+  fchmod_cb_count = 0;
+
+  r = req.open("test_file", O_RDWR | O_CREAT, S_IWUSR | S_IRUSR);
+  ASSERT(r >= 0);
+  ASSERT(req.result >= 0);
+  file = req.result;
+  req.cleanup();
+
+  iov = uv_buf_init(test_buf, sizeof(test_buf));
+  r = req.write(file, { iov }, -1);
+  ASSERT(r == sizeof(test_buf));
+  ASSERT(req.result == sizeof(test_buf));
+  req.cleanup();
+
+#ifndef _WIN32
+  /* Make the file write-only */
+  r = req.chmod("test_file", 0200);
+  ASSERT(r == 0);
+  ASSERT(req.result == 0);
+  req.cleanup();
+
+  check_permission("test_file", 0200);
+#endif
+
+  /* Make the file read-only */
+  r = req.chmod("test_file", 0400);
+  ASSERT(r == 0);
+  ASSERT(req.result == 0);
+  req.cleanup();
+
+  check_permission("test_file", 0400);
+
+  /* Make the file read+write with sync uv_fs_fchmod */
+  r = req.fchmod(file, 0600);
+  ASSERT(r == 0);
+  ASSERT(req.result == 0);
+  req.cleanup();
+
+  check_permission("test_file", 0600);
+
+#ifndef _WIN32
+  /* async chmod */
+  {
+    static int mode = 0200;
+    req.data = &mode;
+  }
+  r = req.chmod(loop, "test_file", 0200, chmod_cb, TO_WEAK(sp));
+  ASSERT(r == 0);
+  uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT(chmod_cb_count == 1);
+  chmod_cb_count = 0; /* reset for the next test */
+#endif
+
+  /* async chmod */
+  {
+    static int mode = 0400;
+    req.data = &mode;
+  }
+  r = req.chmod(loop, "test_file", 0400, chmod_cb, TO_WEAK(sp));
+  ASSERT(r == 0);
+  uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT(chmod_cb_count == 1);
+
+  /* async fchmod */
+  {
+    static int mode = 0600;
+    req.data = &mode;
+  }
+  r = req.fchmod(loop, file, 0600, fchmod_cb, TO_WEAK(sp));
+  ASSERT(r == 0);
+  uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT(fchmod_cb_count == 1);
+
+  r = req.close(file);
+
+  /*
+   * Run the loop just to check we don't have make any extraneous uv_ref()
+   * calls. This should drop out immediately.
+   */
+  uv_run(loop, UV_RUN_DEFAULT);
+
+  /* Cleanup. */
+  w_unlink("test_file");
+
+  make_valgrind_happy();
+}
+
+
+static void chown_cb(ns_fs* req, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  ASSERT(req->fs_type == UV_FS_CHOWN);
+  ASSERT(req->result == 0);
+  chown_cb_count++;
+  req->cleanup();
+}
+
+static void chown_root_cb(ns_fs* req, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  ASSERT(req->fs_type == UV_FS_CHOWN);
+#if defined(_WIN32) || defined(__MSYS__)
+  /* On windows, chown is a no-op and always succeeds. */
+  ASSERT(req->result == 0);
+#else
+  /* On unix, chown'ing the root directory is not allowed -
+   * unless you're root, of course.
+   */
+  if (geteuid() == 0)
+    ASSERT(req->result == 0);
+  else
+#   if defined(__CYGWIN__)
+    /* On Cygwin, uid 0 is invalid (no root). */
+    ASSERT(req->result == UV_EINVAL);
+#   elif defined(__PASE__)
+    /* On IBMi PASE, there is no root user. uid 0 is user qsecofr.
+     * User may grant qsecofr's privileges, including changing
+     * the file's ownership to uid 0.
+     */
+    ASSERT(req->result == 0 || req->result == UV_EPERM);
+#   else
+    ASSERT(req->result == UV_EPERM);
+#   endif
+#endif
+  chown_cb_count++;
+  req->cleanup();
+}
+
+static void fchown_cb(ns_fs* req, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  ASSERT(req->fs_type == UV_FS_FCHOWN);
+  ASSERT(req->result == 0);
+  fchown_cb_count++;
+  req->cleanup();
+}
+
+static void lchown_cb(ns_fs* req, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  ASSERT(req->fs_type == UV_FS_LCHOWN);
+  ASSERT(req->result == 0);
+  lchown_cb_count++;
+  req->cleanup();
+}
+
+TEST_CASE("fs_chown_wp", "[fs]") {
+  std::shared_ptr<size_t> sp = std::make_shared<size_t>(42);
+  int r;
+  ns_fs req;
+  uv_file file;
+  uv_loop_t* loop;
+
+  /* Setup. */
+  w_unlink("test_file");
+  w_unlink("test_file_link");
+
+  loop = uv_default_loop();
+  chown_cb_count = 0;
+  fchown_cb_count = 0;
+  lchown_cb_count = 0;
+
+  r = req.open("test_file", O_RDWR | O_CREAT, S_IWUSR | S_IRUSR);
+  ASSERT(r >= 0);
+  ASSERT(req.result >= 0);
+  file = req.result;
+  req.cleanup();
+
+  /* sync chown */
+  r = req.chown("test_file", -1, -1);
+  ASSERT(r == 0);
+  ASSERT(req.result == 0);
+  req.cleanup();
+
+  /* sync fchown */
+  r = req.fchown(file, -1, -1);
+  ASSERT(r == 0);
+  ASSERT(req.result == 0);
+  req.cleanup();
+
+  /* async chown */
+  r = req.chown(loop, "test_file", -1, -1, chown_cb, TO_WEAK(sp));
+  ASSERT(r == 0);
+  uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT(chown_cb_count == 1);
+
+#ifndef __MVS__
+  /* chown to root (fail) */
+  chown_cb_count = 0;
+  r = req.chown(loop, "test_file", 0, 0, chown_root_cb, TO_WEAK(sp));
+  ASSERT(r == 0);
+  uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT(chown_cb_count == 1);
+#endif
+
+  /* async fchown */
+  r = req.fchown(loop, file, -1, -1, fchown_cb, TO_WEAK(sp));
+  ASSERT(r == 0);
+  uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT(fchown_cb_count == 1);
+
+#ifndef __HAIKU__
+  /* Haiku doesn't support hardlink */
+  /* sync link */
+  r = req.link("test_file", "test_file_link");
+  ASSERT(r == 0);
+  ASSERT(req.result == 0);
+  req.cleanup();
+
+  /* sync lchown */
+  r = req.lchown("test_file_link", -1, -1);
+  ASSERT(r == 0);
+  ASSERT(req.result == 0);
+  req.cleanup();
+
+  /* async lchown */
+  r = req.lchown(loop, "test_file_link", -1, -1, lchown_cb, TO_WEAK(sp));
+  ASSERT(r == 0);
+  uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT(lchown_cb_count == 1);
+#endif
+
+  /* Close file */
+  r = req.close(file);
+  ASSERT(r == 0);
+  ASSERT(req.result == 0);
+  req.cleanup();
+
+  /*
+   * Run the loop just to check we don't have make any extraneous uv_ref()
+   * calls. This should drop out immediately.
+   */
+  uv_run(loop, UV_RUN_DEFAULT);
+
+  /* Cleanup. */
+  w_unlink("test_file");
+  w_unlink("test_file_link");
+
+  make_valgrind_happy();
+}
+
+
+static void link_cb(ns_fs* req, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  ASSERT(req->fs_type == UV_FS_LINK);
+  ASSERT(req->result == 0);
+  link_cb_count++;
+  req->cleanup();
+}
+
+TEST_CASE("fs_link_wp", "[fs]") {
+  std::shared_ptr<size_t> sp = std::make_shared<size_t>(42);
+  int r;
+  ns_fs req;
+  uv_file file;
+  uv_file link;
+  uv_loop_t* loop;
+
+  /* Setup. */
+  w_unlink("test_file");
+  w_unlink("test_file_link");
+  w_unlink("test_file_link2");
+
+  loop = uv_default_loop();
+  link_cb_count = 0;
+
+  r = req.open("test_file", O_RDWR | O_CREAT, S_IWUSR | S_IRUSR);
+  ASSERT(r >= 0);
+  ASSERT(req.result >= 0);
+  file = req.result;
+  req.cleanup();
+
+  r = req.write(file, { uv_buf_init(test_buf, sizeof(test_buf)) }, -1);
+  ASSERT(r == sizeof(test_buf));
+  ASSERT(req.result == sizeof(test_buf));
+  req.cleanup();
+
+  r = req.close(file);
+
+  /* async link */
+  r = req.link(loop, "test_file", "test_file_link2", link_cb, TO_WEAK(sp));
+  ASSERT(r == 0);
+  uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT(link_cb_count == 1);
+
+  r = req.open("test_file_link2", O_RDWR, 0);
+  ASSERT(r >= 0);
+  ASSERT(req.result >= 0);
+  link = req.result;
+  req.cleanup();
+
+  memset(buf, 0, sizeof(buf));
+  iov = uv_buf_init(buf, sizeof(buf));
+  r = req.read(link, &iov, 1, 0);
+  ASSERT(r >= 0);
+  ASSERT(req.result >= 0);
+
+  r = req.close(link);
+
+  /*
+   * Run the loop just to check we don't have make any extraneous uv_ref()
+   * calls. This should drop out immediately.
+   */
+  uv_run(loop, UV_RUN_DEFAULT);
+
+  /* Cleanup. */
+  w_unlink("test_file");
+  w_unlink("test_file_link");
+  w_unlink("test_file_link2");
+
+  make_valgrind_happy();
+}
+
+
+static void dummy_cb(ns_fs*, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  dummy_cb_count++;
+}
+
+
+TEST_CASE("fs_readlink_wp", "[fs]") {
+  std::shared_ptr<size_t> sp = std::make_shared<size_t>(42);
+  /* Must return UV_ENOENT on an inexistent file */
+  {
+    ns_fs req;
+    uv_loop_t* loop;
+
+    loop = uv_default_loop();
+    dummy_cb_count = 0;
+    ASSERT(0 == req.readlink(loop, "no_such_file", dummy_cb, TO_WEAK(sp)));
+    ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
+    ASSERT(dummy_cb_count == 1);
+    ASSERT_NULL(req.ptr);
+    ASSERT(req.result == UV_ENOENT);
+    req.cleanup();
+
+    ASSERT(UV_ENOENT == req.readlink("no_such_file"));
+    ASSERT_NULL(req.ptr);
+    ASSERT(req.result == UV_ENOENT);
+    req.cleanup();
+  }
+
+  /* Must return UV_EINVAL on a non-symlink file */
+  {
+    int r;
+    ns_fs req;
+    uv_file file;
+
+    /* Setup */
+
+    /* Create a non-symlink file */
+    r = req.open("test_file", O_RDWR | O_CREAT, S_IWUSR | S_IRUSR);
+    ASSERT_GE(r, 0);
+    ASSERT_GE(req.result, 0);
+    file = req.result;
+    req.cleanup();
+
+    r = req.close(file);
+    ASSERT_EQ(r, 0);
+    ASSERT_EQ(req.result, 0);
+    req.cleanup();
+
+    /* Test */
+    r = req.readlink("test_file");
+    ASSERT_EQ(r, UV_EINVAL);
+    req.cleanup();
+
+    /* Cleanup */
+    w_unlink("test_file");
+  }
+
+  make_valgrind_happy();
+}
+
+
+TEST_CASE("fs_realpath_wp", "[fs]") {
+  std::shared_ptr<size_t> sp = std::make_shared<size_t>(42);
+  ns_fs req;
+  uv_loop_t* loop;
+
+  loop = uv_default_loop();
+  dummy_cb_count = 0;
+  ASSERT(0 == req.realpath(loop, "no_such_file", dummy_cb, TO_WEAK(sp)));
+  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT(dummy_cb_count == 1);
+  ASSERT_NULL(req.ptr);
+  ASSERT(req.result == UV_ENOENT);
+  req.cleanup();
+
+  ASSERT(UV_ENOENT == req.realpath("no_such_file"));
+  ASSERT_NULL(req.ptr);
+  ASSERT(req.result == UV_ENOENT);
+  req.cleanup();
+
+  make_valgrind_happy();
+}
+
+
+static void symlink_cb(ns_fs* req, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  ASSERT(req->fs_type == UV_FS_SYMLINK);
+  ASSERT(req->result == 0);
+  symlink_cb_count++;
+  req->cleanup();
+}
+
+static void readlink_cb(ns_fs* req, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  ASSERT(req->fs_type == UV_FS_READLINK);
+  ASSERT(req->result == 0);
+  readlink_cb_count++;
+  req->cleanup();
+}
+
+static void realpath_cb(ns_fs* req, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  char test_file_abs_buf[PATHMAX];
+  size_t test_file_abs_size = sizeof(test_file_abs_buf);
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  ASSERT(req->fs_type == UV_FS_REALPATH);
+  ASSERT(req->result == 0);
+
+  uv_cwd(test_file_abs_buf, &test_file_abs_size);
+#ifdef _WIN32
+  strcat_s(test_file_abs_buf, sizeof(test_file_abs_buf), "\\test_file"); // NOLINT
+  ASSERT(w_stricmp(static_cast<char*>(req->ptr), test_file_abs_buf) == 0);
+#else
+  strcat(test_file_abs_buf, "/test_file"); // NOLINT
+  // ASSERT(strcmp(req->ptr, test_file_abs_buf) == 0);
+#endif
+  realpath_cb_count++;
+  req->cleanup();
+}
+
+TEST_CASE("fs_symlink_wp", "[fs]") {
+  std::shared_ptr<size_t> sp = std::make_shared<size_t>(42);
+  int r;
+  ns_fs req;
+  uv_file file;
+  uv_file link;
+  uv_loop_t* loop;
+  char test_file_abs_buf[PATHMAX];
+  size_t test_file_abs_size;
+
+  /* Setup. */
+  symlink_cb_count = 0;
+  readlink_cb_count = 0;
+  realpath_cb_count = 0;
+  w_unlink("test_file");
+  w_unlink("test_file_symlink");
+  w_unlink("test_file_symlink2");
+  w_unlink("test_file_symlink_symlink");
+  w_unlink("test_file_symlink2_symlink");
+  test_file_abs_size = sizeof(test_file_abs_buf);
+#ifdef _WIN32
+  uv_cwd(test_file_abs_buf, &test_file_abs_size);
+  strcat_s(
+      test_file_abs_buf, sizeof(test_file_abs_buf), "\\test_file");  // NOLINT
+#else
+  uv_cwd(test_file_abs_buf, &test_file_abs_size);
+  strcat(test_file_abs_buf, "/test_file"); // NOLINT
+#endif
+
+  loop = uv_default_loop();
+
+  r = req.open("test_file", O_RDWR | O_CREAT, S_IWUSR | S_IRUSR);
+  ASSERT(r >= 0);
+  ASSERT(req.result >= 0);
+  file = req.result;
+  req.cleanup();
+
+  iov = uv_buf_init(test_buf, sizeof(test_buf));
+  r = req.write(file, &iov, 1, -1);
+  ASSERT(r == sizeof(test_buf));
+  ASSERT(req.result == sizeof(test_buf));
+  req.cleanup();
+
+  r = req.close(file);
+
+  /* async link */
+  r = req.symlink(
+      loop, "test_file", "test_file_symlink2", 0, symlink_cb, TO_WEAK(sp));
+  ASSERT(r == 0);
+  uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT(symlink_cb_count == 1);
+
+  r = req.open("test_file_symlink2", O_RDWR, 0);
+  ASSERT(r >= 0);
+  ASSERT(req.result >= 0);
+  link = req.result;
+  req.cleanup();
+
+  memset(buf, 0, sizeof(buf));
+  iov = uv_buf_init(buf, sizeof(buf));
+  r = req.read(link, &iov, 1, 0);
+  ASSERT(r >= 0);
+  ASSERT(req.result >= 0);
+
+  r = req.close(link);
+
+  r = req.symlink("test_file_symlink2", "test_file_symlink2_symlink", 0);
+  ASSERT(r == 0);
+  req.cleanup();
+
+  r = req.readlink(
+      loop, "test_file_symlink2_symlink", readlink_cb, TO_WEAK(sp));
+  ASSERT(r == 0);
+  uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT(readlink_cb_count == 1);
+
+  r = req.realpath(loop, "test_file", realpath_cb, TO_WEAK(sp));
+  ASSERT(r == 0);
+  uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT(realpath_cb_count == 1);
+
+  /*
+   * Run the loop just to check we don't have make any extraneous uv_ref()
+   * calls. This should drop out immediately.
+   */
+  uv_run(loop, UV_RUN_DEFAULT);
+
+  /* Cleanup. */
+  w_unlink("test_file");
+  w_unlink("test_file_symlink");
+  w_unlink("test_file_symlink_symlink");
+  w_unlink("test_file_symlink2");
+  w_unlink("test_file_symlink2_symlink");
+
+  make_valgrind_happy();
+}
+
+
+static void utime_cb(ns_fs* req, std::weak_ptr<utime_check_t> wp) {
+  auto c = wp.lock();
+  ASSERT(c);
+  ASSERT(req->result == 0);
+  ASSERT(req->fs_type == UV_FS_UTIME);
+  ASSERT(req->get_data<utime_check_t>() == c.get());
+
+  check_utime(c->path, c->atime, c->mtime, /* test_lutime */ 0);
+
+  req->cleanup();
+  utime_cb_count++;
+}
+
+
+TEST_CASE("fs_utime_wp", "[fs]") {
+  auto checkme = std::make_shared<utime_check_t>();
+  const char* path = "test_file";
+  double atime;
+  double mtime;
+  ns_fs utime_req;
+  ns_fs req;
+  uv_loop_t* loop;
+  int r;
+
+  /* Setup. */
+  loop = uv_default_loop();
+  utime_cb_count = 0;
+  w_unlink(path);
+  r = req.open(path, O_RDWR | O_CREAT, S_IWUSR | S_IRUSR);
+  ASSERT(r >= 0);
+  ASSERT(req.result >= 0);
+  req.cleanup();
+  ASSERT_EQ(0, req.close(r));
+
+  atime = mtime = 400497753.25; /* 1982-09-10 11:22:33.25 */
+
+  r = req.utime(path, atime, mtime);
+  ASSERT(r == 0);
+  ASSERT(req.result == 0);
+  req.cleanup();
+
+  check_utime(path, atime, mtime, /* test_lutime */ 0);
+
+  atime = mtime = 1291404900.25; /* 2010-12-03 20:35:00.25 - mees <3 */
+  checkme->path = path;
+  checkme->atime = atime;
+  checkme->mtime = mtime;
+
+  /* async utime */
+  utime_req.data = checkme.get();
+  r = utime_req.utime(loop, path, atime, mtime, utime_cb, TO_WEAK(checkme));
+  ASSERT(r == 0);
+  uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT(utime_cb_count == 1);
+
+  /* Cleanup. */
+  w_unlink(path);
+
+  make_valgrind_happy();
+}
+
+
+static void futime_cb(ns_fs* req, std::weak_ptr<utime_check_t> wp) {
+  auto c = wp.lock();
+  ASSERT(req->result == 0);
+  ASSERT(req->fs_type == UV_FS_FUTIME);
+  ASSERT(req->get_data<utime_check_t>() == c.get());
+
+  check_utime(c->path, c->atime, c->mtime, /* test_lutime */ 0);
+
+  req->cleanup();
+  futime_cb_count++;
+}
+
+
+TEST_CASE("fs_futime_wp", "[fs]") {
+  auto checkme = std::make_shared<utime_check_t>();
+  const char* path = "test_file";
+  double atime;
+  double mtime;
+  uv_file file;
+  ns_fs futime_req;
+  ns_fs req;
+  uv_loop_t* loop;
+  int r;
+#if defined(_AIX) && !defined(_AIX71)
+  RETURN_SKIP("futime is not implemented for AIX versions below 7.1");
+#endif
+
+  /* Setup. */
+  loop = uv_default_loop();
+  futime_cb_count = 0;
+  w_unlink(path);
+  r = req.open(path, O_RDWR | O_CREAT, S_IWUSR | S_IRUSR);
+  ASSERT(r >= 0);
+  ASSERT(req.result >= 0);
+  req.cleanup();
+  r = req.close(r);
+  ASSERT(r == 0);
+
+  atime = mtime = 400497753.25; /* 1982-09-10 11:22:33.25 */
+
+  r = req.open(path, O_RDWR, 0);
+  ASSERT(r >= 0);
+  ASSERT(req.result >= 0);
+  file = req.result; /* FIXME probably not how it's supposed to be used */
+  req.cleanup();
+
+  r = req.futime(file, atime, mtime);
+#if defined(__CYGWIN__) || defined(__MSYS__)
+  ASSERT(r == UV_ENOSYS);
+  RETURN_SKIP("futime not supported on Cygwin");
+#else
+  ASSERT(r == 0);
+  ASSERT(req.result == 0);
+#endif
+  req.cleanup();
+
+  check_utime(path, atime, mtime, /* test_lutime */ 0);
+
+  atime = mtime = 1291404900; /* 2010-12-03 20:35:00 - mees <3 */
+
+  checkme->atime = atime;
+  checkme->mtime = mtime;
+  checkme->path = path;
+
+  /* async futime */
+  futime_req.data = checkme.get();
+  r = futime_req.futime(loop, file, atime, mtime, futime_cb, TO_WEAK(checkme));
+  ASSERT(r == 0);
+  uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT(futime_cb_count == 1);
+
+  /* Cleanup. */
+  w_unlink(path);
+  futime_req.cleanup();
+
+  make_valgrind_happy();
+}
+
+
+static void lutime_cb(ns_fs* req, std::weak_ptr<utime_check_t> wp) {
+  auto c = wp.lock();
+  ASSERT(c);
+  ASSERT(req->result == 0);
+  ASSERT(req->fs_type == UV_FS_LUTIME);
+  ASSERT(req->get_data<utime_check_t>() == c.get());
+
+  check_utime(c->path, c->atime, c->mtime, /* test_lutime */ 1);
+
+  uv_fs_req_cleanup(req);
+  lutime_cb_count++;
+}
+
+
+TEST_CASE("fs_lutime_wp", "[fs]") {
+  auto checkme = std::make_shared<utime_check_t>();
+  const char* path = "test_file";
+  const char* symlink_path = "test_file_symlink";
+  double atime;
+  double mtime;
+  ns_fs req;
+  uv_loop_t* loop;
+  int r, s;
+
+
+  /* Setup */
+  loop = uv_default_loop();
+  lutime_cb_count = 0;
+  w_unlink(path);
+  r = req.open(path, O_RDWR | O_CREAT, S_IWUSR | S_IRUSR);
+  ASSERT_GE(r, 0);
+  ASSERT_GE(req.result, 0);
+  req.cleanup();
+  r = req.close(r);
+  ASSERT_EQ(r, 0);
+
+  w_unlink(symlink_path);
+  s = req.symlink(path, symlink_path, 0);
+#ifdef _WIN32
+  if (s == UV_EPERM) {
+    /*
+     * Creating a symlink before Windows 10 Creators Update was only allowed
+     * when running elevated console (with admin rights)
+     */
+    RETURN_SKIP(
+        "Symlink creation requires elevated console (with admin rights)");
+  }
+#endif
+  ASSERT_EQ(s, 0);
+  ASSERT_EQ(req.result, 0);
+  req.cleanup();
+
+  /* Test the synchronous version. */
+  atime = mtime = 400497753.25; /* 1982-09-10 11:22:33.25 */
+
+  checkme->atime = atime;
+  checkme->mtime = mtime;
+  checkme->path = symlink_path;
+  req.data = checkme.get();
+
+  r = req.lutime(symlink_path, atime, mtime);
+#if (defined(_AIX) && !defined(_AIX71)) ||                                    \
+     defined(__MVS__)
+  ASSERT_EQ(r, UV_ENOSYS);
+  RETURN_SKIP("lutime is not implemented for z/OS and AIX versions below 7.1");
+#endif
+  ASSERT_EQ(r, 0);
+  lutime_cb(&req, TO_WEAK(checkme));
+  ASSERT_EQ(lutime_cb_count, 1);
+
+  /* Test the asynchronous version. */
+  atime = mtime = 1291404900; /* 2010-12-03 20:35:00 */
+
+  checkme->atime = atime;
+  checkme->mtime = mtime;
+  checkme->path = symlink_path;
+
+  r = req.lutime(loop, symlink_path, atime, mtime, lutime_cb, TO_WEAK(checkme));
+  ASSERT_EQ(r, 0);
+  uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT_EQ(lutime_cb_count, 2);
+
+  /* Cleanup. */
+  w_unlink(path);
+  w_unlink(symlink_path);
+
+  make_valgrind_happy();
+}
+
+
+static void empty_scandir_cb(ns_fs* req, std::weak_ptr<ns_fs> wp) {
+  auto scandir_req = wp.lock();
+  uv_dirent_t dent;
+
+  ASSERT(scandir_req);
+  ASSERT(req == scandir_req.get());
+  ASSERT(req->fs_type == UV_FS_SCANDIR);
+  ASSERT(req->result == 0);
+  ASSERT_NULL(req->ptr);
+  ASSERT(UV_EOF == req->scandir_next(&dent));
+  req->cleanup();
+  scandir_cb_count++;
+}
+
+
+TEST_CASE("fs_scandir_empty_dir_wp", "[fs]") {
+  const char* path;
+  ns_fs req;
+  auto scandir_req = std::make_shared<ns_fs>();
+  uv_dirent_t dent;
+  uv_loop_t* loop;
+  int r;
+
+  loop = uv_default_loop();
+  scandir_cb_count = 0;
+  path = "./empty_dir/";
+
+  r = req.mkdir(path, 0777);
+  req.cleanup();
+
+  /* Fill the req to ensure that required fields are cleaned up */
+  memset(req.uv_req(), 0xdb, sizeof(*req.uv_req()));
+
+  r = req.scandir(path, 0);
+  ASSERT(r == 0);
+  ASSERT(req.result == 0);
+  ASSERT_NULL(req.ptr);
+  ASSERT(UV_EOF == req.scandir_next(&dent));
+  req.cleanup();
+
+  r = scandir_req->scandir(
+      loop, path, 0, empty_scandir_cb, TO_WEAK(scandir_req));
+  ASSERT(r == 0);
+
+  ASSERT(scandir_cb_count == 0);
+  uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT(scandir_cb_count == 1);
+
+  r = req.rmdir(path);
+  req.cleanup();
+  scandir_req->cleanup();
+
+  make_valgrind_happy();
+}
+
+
+static void non_existent_scandir_cb(ns_fs* req, std::weak_ptr<ns_fs> wp) {
+  auto scandir_req = wp.lock();
+  uv_dirent_t dent;
+
+  ASSERT(scandir_req);
+  ASSERT(req == scandir_req.get());
+  ASSERT(req->fs_type == UV_FS_SCANDIR);
+  ASSERT(req->result == UV_ENOENT);
+  ASSERT_NULL(req->ptr);
+  ASSERT(UV_ENOENT == req->scandir_next(&dent));
+  req->cleanup();
+  scandir_cb_count++;
+}
+
+TEST_CASE("fs_scandir_non_existent_dir_wp", "[fs]") {
+  uv_loop_t* loop;
+  auto req = std::make_shared<ns_fs>();
+  uv_dirent_t dent;
+  const char path[] = "./non_existent_dir/";
+  int r;
+
+  loop = uv_default_loop();
+  scandir_cb_count = 0;
+
+  r = req->rmdir(path);
+  req->cleanup();
+
+  /* Fill the req to ensure that required fields are cleaned up */
+  memset(req->uv_req(), 0xdb, sizeof(*req->uv_req()));
+
+  r = req->scandir(path, 0);
+  ASSERT(r == UV_ENOENT);
+  ASSERT(req->result == UV_ENOENT);
+  ASSERT_NULL(req->ptr);
+  ASSERT(UV_ENOENT == req->scandir_next(&dent));
+  req->cleanup();
+
+  r = req->scandir(loop, path, 0, non_existent_scandir_cb, TO_WEAK(req));
+  ASSERT(r == 0);
+
+  ASSERT(scandir_cb_count == 0);
+  uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT(scandir_cb_count == 1);
+
+  make_valgrind_happy();
+}
+
+
+static void file_scandir_cb(ns_fs* req, std::weak_ptr<ns_fs> wp) {
+  auto scandir_req = wp.lock();
+  ASSERT(scandir_req);
+  ASSERT(req == scandir_req.get());
+  ASSERT(req->fs_type == UV_FS_SCANDIR);
+  ASSERT(req->result == UV_ENOTDIR);
+  ASSERT_NULL(req->ptr);
+  req->cleanup();
+  scandir_cb_count++;
+}
+
+TEST_CASE("fs_scandir_file_wp", "[fs]") {
+  auto scandir_req = std::make_shared<ns_fs>();
+  uv_loop_t* loop;
+  const char path[] = "test/fixtures/empty_file";
+  int r;
+
+  loop = uv_default_loop();
+  scandir_cb_count = 0;
+
+  r = scandir_req->scandir(path, 0);
+  ASSERT(r == UV_ENOTDIR);
+  scandir_req->cleanup();
+
+  r = scandir_req->scandir(
+      loop, path, 0, file_scandir_cb, TO_WEAK(scandir_req));
+  ASSERT(r == 0);
+
+  ASSERT(scandir_cb_count == 0);
+  uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT(scandir_cb_count == 1);
+
+  make_valgrind_happy();
+}
+
+
+static void open_cb_simple(ns_fs* req, std::weak_ptr<ns_fs> wp) {
+  auto open_req = wp.lock();
+  ASSERT(open_req);
+  ASSERT(req->fs_type == UV_FS_OPEN);
+  ASSERT_EQ(req, open_req.get());
+  if (req->result < 0) {
+    fprintf(stderr, "async open error: %d\n", static_cast<int>(req->result));
+    FAIL("error");
+  }
+  open_cb_count++;
+  ASSERT(req->path);
+  req->cleanup();
+}
+
+TEST_CASE("fs_open_dir_wp", "[fs]") {
+  auto open_req = std::make_shared<ns_fs>();
+  ns_fs close_req;
+  uv_loop_t* loop;
+  const char path[] = ".";
+  int r;
+  int file;
+
+  loop = uv_default_loop();
+  open_cb_count = 0;
+
+  r = open_req->open(path, O_RDONLY, 0);
+  ASSERT(r >= 0);
+  ASSERT(open_req->result >= 0);
+  ASSERT_NULL(open_req->ptr);
+  file = r;
+  open_req->cleanup();
+
+  r = close_req.close(file);
+  ASSERT(r == 0);
+  close_req.cleanup();
+
+  r = open_req->open(
+      loop, path, O_RDONLY, 0, open_cb_simple, TO_WEAK(open_req));
+  ASSERT(r == 0);
+
+  ASSERT(open_cb_count == 0);
+  uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT(open_cb_count == 1);
+
+  make_valgrind_happy();
+}
+
+
+TEST_CASE("fs_read_dir_wp", "[fs]") {
+  auto mkdir_req = std::make_shared<ns_fs>();
+  ns_fs close_req;
+  ns_fs open_req;
+  ns_fs read_req;
+  uv_loop_t* loop;
+  uv_buf_t iov;
+  int r;
+  char buf[2];
+
+  loop = uv_default_loop();
+  mkdir_cb_count = 0;
+
+  /* Setup */
+  w_rmdir("test_dir");
+  r = mkdir_req->mkdir(loop, "test_dir", 0755, mkdir_cb, TO_WEAK(mkdir_req));
+  ASSERT(r == 0);
+  uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT(mkdir_cb_count == 1);
+  /* Setup Done Here */
+
+  /* Get a file descriptor for the directory */
+  r = open_req.open("test_dir",
+                    UV_FS_O_RDONLY | UV_FS_O_DIRECTORY,
+                    S_IWUSR | S_IRUSR);
+  ASSERT(r >= 0);
+  open_req.cleanup();
+
+  /* Try to read data from the directory */
+  iov = uv_buf_init(buf, sizeof(buf));
+  r = read_req.read(open_req.result, &iov, 1, 0);
+#if defined(__FreeBSD__)   || \
+    defined(__OpenBSD__)   || \
+    defined(__NetBSD__)    || \
+    defined(__DragonFly__) || \
+    defined(_AIX)          || \
+    defined(__sun)         || \
+    defined(__MVS__)
+  /*
+   * As of now, these operating systems support reading from a directory,
+   * that too depends on the filesystem this temporary test directory is
+   * created on. That is why this assertion is a bit lenient.
+   */
+  ASSERT((r >= 0) || (r == UV_EISDIR));
+#else
+  ASSERT(r == UV_EISDIR);
+#endif
+  read_req.cleanup();
+
+  r = close_req.close(open_req.result);
+  ASSERT(r == 0);
+  close_req.cleanup();
+
+  /* Cleanup */
+  w_rmdir("test_dir");
+
+  make_valgrind_happy();
+}
+
+
+static void statfs_cb(ns_fs* req) {
+  uv_statfs_t* stats;
+
+  ASSERT(req->fs_type == UV_FS_STATFS);
+  ASSERT(req->result == 0);
+  ASSERT_NOT_NULL(req->ptr);
+  stats = static_cast<uv_statfs_t*>(req->ptr);
+
+#if defined(_WIN32) || defined(__sun) || defined(_AIX) || defined(__MVS__) || \
+  defined(__OpenBSD__) || defined(__NetBSD__)
+  ASSERT(stats->f_type == 0);
+#else
+  ASSERT(stats->f_type > 0);
+#endif
+
+  ASSERT(stats->f_bsize > 0);
+  ASSERT(stats->f_blocks > 0);
+  ASSERT(stats->f_bfree <= stats->f_blocks);
+  ASSERT(stats->f_bavail <= stats->f_bfree);
+
+#ifdef _WIN32
+  ASSERT(stats->f_files == 0);
+  ASSERT(stats->f_ffree == 0);
+#else
+  /* There is no assertion for stats->f_files that makes sense, so ignore it. */
+  ASSERT(stats->f_ffree <= stats->f_files);
+#endif
+  req->cleanup();
+  ASSERT_NULL(req->ptr);
+  statfs_cb_count++;
+}
+
+static void statfs_cb(ns_fs* req, std::weak_ptr<ns_fs> wp) {
+  auto data = wp.lock();
+  ASSERT(data);
+  ASSERT_EQ(req, data.get());
+  statfs_cb(req);
+}
+
+TEST_CASE("fs_statfs_wp", "[fs]") {
+  std::shared_ptr<ns_fs> req = std::make_shared<ns_fs>();
+  int r;
+  uv_loop_t* loop;
+
+  loop = uv_default_loop();
+  statfs_cb_count = 0;
+
+  /* Test passing data. */
+  r = req->statfs(loop, ".", statfs_cb, TO_WEAK(req));
+  ASSERT(r == 0);
+  uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT(statfs_cb_count == 1);
+
+  make_valgrind_happy();
+}

--- a/test/test-fs.cc
+++ b/test/test-fs.cc
@@ -354,9 +354,9 @@ static void check_utime(const char* path,
     ASSERT_DOUBLE_EQ(atime, static_cast<uint32_t>(atime));
     ASSERT_DOUBLE_EQ(mtime, static_cast<uint32_t>(atime));
 #endif
-    if (atime > 0 || static_cast<uint32_t>(atime == atime))
+    if (atime > 0 || static_cast<uint32_t>(atime) == atime)
       ASSERT_EQ(s->st_atim.tv_sec, static_cast<uint32_t>(atime));
-    if (mtime > 0 || static_cast<uint32_t>(mtime == mtime))
+    if (mtime > 0 || static_cast<uint32_t>(mtime) == mtime)
       ASSERT_EQ(s->st_mtim.tv_sec, static_cast<uint32_t>(mtime));
     ASSERT_GE(s->st_atim.tv_sec, static_cast<uint32_t>(atime) - 1);
     ASSERT_GE(s->st_mtim.tv_sec, static_cast<uint32_t>(mtime) - 1);

--- a/test/test-random-wp.cc
+++ b/test/test-random-wp.cc
@@ -1,0 +1,65 @@
+#include "../include/nsuv-inl.h"
+#include "./catch.hpp"
+#include "./helpers.h"
+
+#include <string.h>
+
+using nsuv::ns_random;
+
+static char scratch[256];
+static int random_cb_called;
+
+
+static void random_cb(ns_random*,
+                      int status,
+                      void* buf,
+                      size_t buflen,
+                      std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  char zero[sizeof(scratch)];
+
+  memset(zero, 0, sizeof(zero));
+
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  ASSERT(0 == status);
+  ASSERT(buf == static_cast<void*>(scratch));
+
+  if (random_cb_called == 0) {
+    ASSERT(buflen == 0);
+    ASSERT(0 == memcmp(scratch, zero, sizeof(zero)));
+  } else {
+    ASSERT(buflen == sizeof(scratch));
+    /* Buy a lottery ticket if you manage to trip this assertion. */
+    ASSERT(0 != memcmp(scratch, zero, sizeof(zero)));
+  }
+
+  random_cb_called++;
+}
+
+
+TEST_CASE("random_async_wp", "[random]") {
+  std::shared_ptr<size_t> sp = std::make_shared<size_t>(42);
+  ns_random req;
+  uv_loop_t* loop;
+
+  loop = uv_default_loop();
+  ASSERT(UV_EINVAL == req.get(
+      loop, scratch, sizeof(scratch), -1, random_cb, TO_WEAK(sp)));
+  ASSERT(UV_E2BIG == req.get(loop, scratch, -1, -1, random_cb, TO_WEAK(sp)));
+
+  ASSERT(0 == req.get(loop, scratch, 0, 0, random_cb, TO_WEAK(sp)));
+  ASSERT(0 == random_cb_called);
+
+  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT(1 == random_cb_called);
+
+  ASSERT(0 == req.get(
+        loop, scratch, sizeof(scratch), 0, random_cb, TO_WEAK(sp)));
+  ASSERT(1 == random_cb_called);
+
+  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
+  ASSERT(2 == random_cb_called);
+
+  make_valgrind_happy();
+}

--- a/test/test-tcp-close-reset-wp.cc
+++ b/test/test-tcp-close-reset-wp.cc
@@ -1,0 +1,350 @@
+#include "../include/nsuv-inl.h"
+#include "./helpers.h"
+
+using nsuv::ns_connect;
+using nsuv::ns_tcp;
+using nsuv::ns_write;
+
+static uv_loop_t* loop;
+static ns_tcp tcp_server;
+static ns_tcp tcp_client;
+static ns_tcp tcp_accepted;
+static ns_connect<ns_tcp> connect_req;
+static uv_shutdown_t shutdown_req;
+static ns_write<ns_tcp> write_reqs[4];
+
+static int client_close;
+static int shutdown_before_close;
+
+static int write_cb_called;
+static int close_cb_called;
+static int shutdown_cb_called;
+
+static void connect_cb(ns_connect<ns_tcp>*, int, std::weak_ptr<size_t>);
+static void write_cb(ns_write<ns_tcp>*, int, std::weak_ptr<size_t>);
+static void close_cb(ns_tcp*, std::weak_ptr<size_t>);
+static void shutdown_cb(uv_shutdown_t*, int);
+
+static int read_size;
+
+static char ping_cstr[] = "PING";
+
+static void zero_global_values() {
+  client_close = 0;
+  shutdown_before_close = 0;
+  write_cb_called = 0;
+  close_cb_called = 0;
+  shutdown_cb_called = 0;
+  read_size = 0;
+}
+
+
+static void do_write(ns_tcp* handle, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  uv_buf_t buf;
+  unsigned i;
+  int r;
+
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+
+  buf = uv_buf_init(ping_cstr, 4);
+  for (i = 0; i < ARRAY_SIZE(write_reqs); i++) {
+    r = handle->write(&write_reqs[i], &buf, 1, write_cb, d);
+    ASSERT(r == 0);
+  }
+}
+
+
+static void do_close(ns_tcp* handle, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+
+  if (shutdown_before_close == 1) {
+    ASSERT(0 == uv_shutdown(
+          &shutdown_req, handle->base_stream(), shutdown_cb));
+    ASSERT(UV_EINVAL == handle->close_reset(close_cb, d));
+  } else {
+    ASSERT(0 == handle->close_reset(close_cb, d));
+    ASSERT(UV_ENOTCONN ==
+           uv_shutdown(&shutdown_req, handle->base_stream(), shutdown_cb));
+  }
+
+  tcp_server.close();
+}
+
+static void alloc_cb(ns_tcp*, size_t, uv_buf_t* buf, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  static char slab[1024];
+
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+
+  buf->base = slab;
+  buf->len = sizeof(slab);
+}
+
+static void read_cb2(ns_tcp* stream,
+                     ssize_t nread,
+                     const uv_buf_t*,
+                     std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+
+  ASSERT(stream == &tcp_client);
+  if (nread == UV_EOF)
+    stream->close();
+}
+
+
+static void connect_cb(ns_connect<ns_tcp>* conn_req,
+                       int,
+                       std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+
+  ASSERT(conn_req == &connect_req);
+  ASSERT(0 == tcp_client.read_start(alloc_cb, read_cb2, d));
+  do_write(&tcp_client, d);
+  if (client_close)
+    do_close(&tcp_client, d);
+}
+
+
+static void write_cb(ns_write<ns_tcp>* req, int, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+
+  /* write callbacks should run before the close callback */
+  ASSERT(close_cb_called == 0);
+  ASSERT(req->handle() == &tcp_client);
+  write_cb_called++;
+}
+
+
+static void close_cb(ns_tcp* handle, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+
+  if (client_close)
+    ASSERT(handle == &tcp_client);
+  else
+    ASSERT(handle == &tcp_accepted);
+
+  close_cb_called++;
+}
+
+
+static void shutdown_cb(uv_shutdown_t* req, int) {
+  if (client_close)
+    ASSERT(req->handle == tcp_client.base_stream());
+  else
+    ASSERT(req->handle == tcp_accepted.base_stream());
+
+  shutdown_cb_called++;
+}
+
+
+static void read_cb(ns_tcp* stream,
+                    ssize_t nread,
+                    const uv_buf_t*,
+                    std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+
+  ASSERT(stream == &tcp_accepted);
+  if (nread < 0) {
+    stream->close();
+  } else {
+    read_size += nread;
+    if (read_size == 16 && client_close == 0)
+      do_close(&tcp_accepted, d);
+  }
+}
+
+
+static void connection_cb(ns_tcp* server, int status, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+
+  ASSERT(status == 0);
+
+  ASSERT(0 == tcp_accepted.init(loop));
+  ASSERT(0 == server->accept(&tcp_accepted));
+
+  ASSERT(0 == tcp_accepted.read_start(alloc_cb, read_cb, d));
+}
+
+
+static void start_server(uv_loop_t* loop,
+                         ns_tcp* handle,
+                         std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  struct sockaddr_in addr;
+  int r;
+
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+
+  ASSERT(0 == uv_ip4_addr("127.0.0.1", kTestPort, &addr));
+
+  r = handle->init(loop);
+  ASSERT(r == 0);
+
+  r = handle->bind(SOCKADDR_CONST_CAST(&addr), 0);
+  ASSERT(r == 0);
+
+  r = handle->listen(128, connection_cb, d);
+  ASSERT(r == 0);
+}
+
+
+static void do_connect(uv_loop_t* loop,
+                       ns_tcp* tcp_client,
+                       std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  struct sockaddr_in addr;
+  int r;
+
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+
+  ASSERT(0 == uv_ip4_addr("127.0.0.1", kTestPort, &addr));
+
+  r = tcp_client->init(loop);
+  ASSERT(r == 0);
+
+  r = tcp_client->connect(&connect_req,
+                          SOCKADDR_CONST_CAST(&addr),
+                          connect_cb,
+                          d);
+  ASSERT(r == 0);
+}
+
+
+/* Check that pending write requests have their callbacks
+ * invoked when the handle is closed.
+ */
+TEST_CASE("tcp_close_reset_client_wp", "[tcp]") {
+  std::shared_ptr<size_t> sp = std::make_shared<size_t>(42);
+  int r;
+
+  zero_global_values();
+
+  loop = uv_default_loop();
+
+  start_server(loop, &tcp_server, TO_WEAK(sp));
+
+  client_close = 1;
+  shutdown_before_close = 0;
+
+  do_connect(loop, &tcp_client, TO_WEAK(sp));
+
+  ASSERT(write_cb_called == 0);
+  ASSERT(close_cb_called == 0);
+  ASSERT(shutdown_cb_called == 0);
+
+  r = uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT(r == 0);
+
+  ASSERT(write_cb_called == 4);
+  ASSERT(close_cb_called == 1);
+  ASSERT(shutdown_cb_called == 0);
+
+  make_valgrind_happy();
+}
+
+TEST_CASE("tcp_close_reset_client_after_shutdown_wp", "[tcp]") {
+  std::shared_ptr<size_t> sp = std::make_shared<size_t>(42);
+  int r;
+
+  zero_global_values();
+
+  loop = uv_default_loop();
+
+  start_server(loop, &tcp_server, TO_WEAK(sp));
+
+  client_close = 1;
+  shutdown_before_close = 1;
+
+  do_connect(loop, &tcp_client, TO_WEAK(sp));
+
+  ASSERT(write_cb_called == 0);
+  ASSERT(close_cb_called == 0);
+  ASSERT(shutdown_cb_called == 0);
+
+  r = uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT(r == 0);
+
+  ASSERT(write_cb_called == 4);
+  ASSERT(close_cb_called == 0);
+  ASSERT(shutdown_cb_called == 1);
+
+  make_valgrind_happy();
+}
+
+TEST_CASE("tcp_close_reset_accepted_wp", "[tcp]") {
+  std::shared_ptr<size_t> sp = std::make_shared<size_t>(42);
+  int r;
+
+  zero_global_values();
+
+  loop = uv_default_loop();
+
+  start_server(loop, &tcp_server, TO_WEAK(sp));
+
+  client_close = 0;
+  shutdown_before_close = 0;
+
+  do_connect(loop, &tcp_client, TO_WEAK(sp));
+
+  ASSERT(write_cb_called == 0);
+  ASSERT(close_cb_called == 0);
+  ASSERT(shutdown_cb_called == 0);
+
+  r = uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT(r == 0);
+
+  ASSERT(write_cb_called == 4);
+  ASSERT(close_cb_called == 1);
+  ASSERT(shutdown_cb_called == 0);
+
+  make_valgrind_happy();
+}
+
+TEST_CASE("tcp_close_reset_accepted_after_shutdown_wp", "[tcp]") {
+  std::shared_ptr<size_t> sp = std::make_shared<size_t>(42);
+  int r;
+
+  zero_global_values();
+
+  loop = uv_default_loop();
+
+  start_server(loop, &tcp_server, TO_WEAK(sp));
+
+  client_close = 0;
+  shutdown_before_close = 1;
+
+  do_connect(loop, &tcp_client, TO_WEAK(sp));
+
+  ASSERT(write_cb_called == 0);
+  ASSERT(close_cb_called == 0);
+  ASSERT(shutdown_cb_called == 0);
+
+  r = uv_run(loop, UV_RUN_DEFAULT);
+  ASSERT(r == 0);
+
+  ASSERT(write_cb_called == 4);
+  ASSERT(close_cb_called == 0);
+  ASSERT(shutdown_cb_called == 1);
+
+  make_valgrind_happy();
+}

--- a/test/test-tcp-close-while-connecting-wp.cc
+++ b/test/test-tcp-close-while-connecting-wp.cc
@@ -1,0 +1,98 @@
+#include "../include/nsuv-inl.h"
+#include "./helpers.h"
+
+using nsuv::ns_connect;
+using nsuv::ns_tcp;
+using nsuv::ns_timer;
+
+static ns_timer timer1_handle;
+static ns_timer timer2_handle;
+static ns_tcp tcp_handle;
+
+static int connect_cb_called;
+static int timer1_cb_called;
+static int close_cb_called;
+static int netunreach_errors;
+
+
+static void close_cb(ns_timer*, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  close_cb_called++;
+}
+
+
+static void close_cb(ns_tcp*, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  close_cb_called++;
+}
+
+
+static void connect_cb(ns_connect<ns_tcp>*,
+                       int status,
+                       std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  /* The expected error is UV_ECANCELED but the test tries to connect to what
+   * is basically an arbitrary address in the expectation that no network path
+   * exists, so UV_ENETUNREACH is an equally plausible outcome.
+   */
+  ASSERT((status == UV_ECANCELED || status == UV_ENETUNREACH));
+  uv_timer_stop(&timer2_handle);
+  connect_cb_called++;
+  if (status == UV_ENETUNREACH)
+    netunreach_errors++;
+}
+
+
+static void timer1_cb(ns_timer* handle, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  handle->close(close_cb, d);
+  tcp_handle.close(close_cb, d);
+  timer1_cb_called++;
+}
+
+
+static void timer2_cb(ns_timer*, std::weak_ptr<size_t>) {
+  FAIL("should not be called");
+}
+
+
+TEST_CASE("tcp_close_while_connecting_wp", "[tcp]") {
+  std::shared_ptr<size_t> sp = std::make_shared<size_t>(42);
+  ns_connect<ns_tcp> connect_req;
+  struct sockaddr_in addr;
+  uv_loop_t* loop;
+  int r;
+
+  loop = uv_default_loop();
+  ASSERT(0 == uv_ip4_addr("1.2.3.4", kTestPort, &addr));
+  ASSERT(0 == tcp_handle.init(loop));
+  r = tcp_handle.connect(&connect_req,
+                         SOCKADDR_CONST_CAST(&addr),
+                         connect_cb,
+                         TO_WEAK(sp));
+  if (r == UV_ENETUNREACH)
+    RETURN_SKIP("Network unreachable.");
+  ASSERT(r == 0);
+  ASSERT(0 == timer1_handle.init(loop));
+  ASSERT(0 == timer1_handle.start(timer1_cb, 1, 0, TO_WEAK(sp)));
+  ASSERT(0 == timer2_handle.init(loop));
+  ASSERT(0 == timer2_handle.start(timer2_cb, 86400 * 1000, 0, TO_WEAK(sp)));
+  ASSERT(0 == uv_run(loop, UV_RUN_DEFAULT));
+
+  ASSERT(connect_cb_called == 1);
+  ASSERT(timer1_cb_called == 1);
+  ASSERT(close_cb_called == 2);
+
+  make_valgrind_happy();
+
+  if (netunreach_errors > 0)
+    RETURN_SKIP("Network unreachable.");
+}

--- a/test/test-tcp-close-wp.cc
+++ b/test/test-tcp-close-wp.cc
@@ -1,0 +1,128 @@
+#include "../include/nsuv-inl.h"
+#include "./helpers.h"
+
+using nsuv::ns_connect;
+using nsuv::ns_tcp;
+using nsuv::ns_write;
+
+constexpr size_t num_write_reqs = 32;
+
+static ns_tcp tcp_handle;
+static ns_connect<ns_tcp> connect_req;
+
+static int write_cb_called;
+static int close_cb_called;
+
+static void connect_cb(ns_connect<ns_tcp>*, int, std::weak_ptr<size_t>);
+static void write_cb(ns_write<ns_tcp>*, int, std::weak_ptr<size_t>);
+static void close_cb(ns_tcp*, std::weak_ptr<size_t>);
+
+
+static void connect_cb(ns_connect<ns_tcp>*,
+                       int status,
+                       std::weak_ptr<size_t> d) {
+  ns_write<ns_tcp>* req;
+  auto sp = d.lock();
+
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+
+  ASSERT_EQ(0, status);
+  for (size_t i = 0; i < num_write_reqs; i++) {
+    char* ping = new char[4]();  // "PING"
+    uv_buf_t buf = uv_buf_init(ping, 4);
+    req = new ns_write<ns_tcp>();
+    ASSERT_NOT_NULL(req);
+    ASSERT_EQ(0, tcp_handle.write(req, &buf, 1, write_cb, d));
+  }
+
+  tcp_handle.close(close_cb, d);
+}
+
+
+static void write_cb(ns_write<ns_tcp>* req,
+                     int status,
+                     std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  const uv_buf_t* bufs;
+  size_t nbufs;
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  /* write callbacks should run before the close callback */
+  ASSERT_EQ(0, status);
+  ASSERT_EQ(0, close_cb_called);
+  ASSERT_EQ(req->handle(), &tcp_handle);
+  write_cb_called++;
+  bufs = req->bufs();
+  nbufs = req->size();
+  for (size_t i = 0; i < nbufs; i++) {
+    delete[] bufs[i].base;
+  }
+  delete req;
+}
+
+
+static void close_cb(ns_tcp* handle, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  ASSERT_EQ(handle, &tcp_handle);
+  close_cb_called++;
+}
+
+
+static void connection_cb(ns_tcp*, int status, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  ASSERT_EQ(0, status);
+}
+
+
+static void start_server(uv_loop_t* loop,
+                         ns_tcp* handle,
+                         std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  struct sockaddr_in addr;
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", kTestPort, &addr));
+  ASSERT_EQ(0, handle->init(loop));
+  ASSERT_EQ(0,
+      handle->bind(reinterpret_cast<const struct sockaddr*>(&addr), 0));
+  ASSERT_EQ(0, handle->listen(128, connection_cb, d));
+  handle->unref();
+}
+
+
+/* Check that pending write requests have their callbacks
+ * invoked when the handle is closed.
+ */
+TEST_CASE("tcp_close_wp", "[tcp]") {
+  std::shared_ptr<size_t> sp = std::make_shared<size_t>(42);
+  struct sockaddr_in addr;
+  ns_tcp tcp_server;
+
+  ASSERT_EQ(0, uv_ip4_addr("127.0.0.1", kTestPort, &addr));
+
+  /* We can't use the echo server, it doesn't handle ECONNRESET. */
+  start_server(uv_default_loop(), &tcp_server, TO_WEAK(sp));
+
+  ASSERT_EQ(0, tcp_handle.init(uv_default_loop()));
+  ASSERT_EQ(0, tcp_handle.connect(
+      &connect_req,
+      reinterpret_cast<const struct sockaddr*>(&addr),
+      connect_cb,
+      TO_WEAK(sp)));
+  ASSERT_EQ(0, write_cb_called);
+  ASSERT_EQ(0, close_cb_called);
+
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+
+  INFO("" << write_cb_called << " of " << num_write_reqs << "write reqs seen");
+
+  ASSERT_EQ(write_cb_called, num_write_reqs);
+  ASSERT_EQ(1, close_cb_called);
+
+  make_valgrind_happy();
+}

--- a/test/test-tcp-write-queue-order-wp.cc
+++ b/test/test-tcp-write-queue-order-wp.cc
@@ -1,0 +1,133 @@
+#include "../include/nsuv-inl.h"
+#include "./helpers.h"
+
+using nsuv::ns_connect;
+using nsuv::ns_tcp;
+using nsuv::ns_timer;
+using nsuv::ns_write;
+
+#define REQ_COUNT 10000
+
+static ns_timer timer;
+static ns_tcp server;
+static ns_tcp client;
+static ns_tcp incoming;
+static int connect_cb_called;
+static int close_cb_called;
+static int connection_cb_called;
+static int write_callbacks;
+static int write_cancelled_callbacks;
+static int write_error_callbacks;
+
+static ns_write<ns_tcp> write_requests[REQ_COUNT];
+
+
+static void close_cb(ns_tcp*, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  close_cb_called++;
+}
+
+static void timer_cb(ns_timer*, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  client.close(close_cb, d);
+  server.close(close_cb, d);
+  incoming.close(close_cb, d);
+}
+
+static void write_cb(ns_write<ns_tcp>*, int status, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  if (status == 0)
+    write_callbacks++;
+  else if (status == UV_ECANCELED)
+    write_cancelled_callbacks++;
+  else
+    write_error_callbacks++;
+}
+
+static void connect_cb(ns_connect<ns_tcp>* req,
+                       int status,
+                       std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  static char base[1024];
+  int r;
+  int i;
+  uv_buf_t buf;
+
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  ASSERT(status == 0);
+  connect_cb_called++;
+
+  buf = uv_buf_init(base, sizeof(base));
+
+  for (i = 0; i < REQ_COUNT; i++) {
+    r = req->handle()->write(&write_requests[i], &buf, 1, write_cb, d);
+    ASSERT(r == 0);
+  }
+}
+
+
+static void connection_cb(ns_tcp* tcp, int status, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  ASSERT(status == 0);
+
+  ASSERT(0 == incoming.init(tcp->get_loop()));
+  ASSERT(0 == tcp->accept(&incoming));
+
+  ASSERT(0 == timer.init(uv_default_loop()));
+  ASSERT(0 == timer.start(timer_cb, 1000, 0, d));
+
+  connection_cb_called++;
+}
+
+
+static void start_server(std::weak_ptr<size_t> d) {
+  struct sockaddr_in addr;
+
+  ASSERT(0 == uv_ip4_addr("0.0.0.0", kTestPort, &addr));
+
+  ASSERT(0 == server.init(uv_default_loop()));
+  ASSERT(0 == server.bind(SOCKADDR_CONST_CAST(&addr), 0));
+  ASSERT(0 == server.listen(128, connection_cb, d));
+}
+
+
+TEST_CASE("tcp_write_queue_order_wp", "[tcp]") {
+  std::shared_ptr<size_t> sp = std::make_shared<size_t>(42);
+  ns_connect<ns_tcp> connect_req;
+  struct sockaddr_in addr;
+  int buffer_size = 16 * 1024;
+
+  start_server(TO_WEAK(sp));
+
+  ASSERT(0 == uv_ip4_addr("127.0.0.1", kTestPort, &addr));
+
+  ASSERT(0 == client.init(uv_default_loop()));
+  ASSERT(0 == client.connect(&connect_req,
+                             SOCKADDR_CONST_CAST(&addr),
+                             connect_cb,
+                             TO_WEAK(sp)));
+  ASSERT(0 == uv_send_buffer_size(client.base_handle(), &buffer_size));
+
+  ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+
+  ASSERT(connect_cb_called == 1);
+  ASSERT(connection_cb_called == 1);
+  ASSERT(write_callbacks > 0);
+  ASSERT(write_cancelled_callbacks > 0);
+  ASSERT(write_callbacks +
+         write_error_callbacks +
+         write_cancelled_callbacks == REQ_COUNT);
+  ASSERT(close_cb_called == 3);
+
+  make_valgrind_happy();
+}

--- a/test/test-thread-wp.cc
+++ b/test/test-thread-wp.cc
@@ -1,0 +1,129 @@
+#include "../include/nsuv-inl.h"
+#include "./helpers.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h> /* memset */
+
+#ifdef __POSIX__
+#include <pthread.h>
+#endif
+
+using nsuv::ns_thread;
+
+static int thread_called;
+static uv_key_t tls_key;
+
+
+static void thread_entry(ns_thread* thread, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  CHECK(!thread->equal(uv_thread_self()));
+  CHECK(*sp == 42);
+  thread_called++;
+}
+
+
+TEST_CASE("thread_create_wp", "[thread]") {
+  std::shared_ptr<size_t> sp = std::make_shared<size_t>(42);
+  ns_thread thread;
+  ASSERT_EQ(0, thread.create(thread_entry, TO_WEAK(sp)));
+  ASSERT_EQ(0, thread.join());
+  ASSERT_EQ(1, thread_called);
+  ASSERT(thread.equal(uv_thread_self()));
+}
+
+
+static void tls_thread(ns_thread* arg, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  CHECK(nullptr == uv_key_get(&tls_key));
+  uv_key_set(&tls_key, arg);
+  CHECK(arg == uv_key_get(&tls_key));
+  uv_key_set(&tls_key, nullptr);
+  CHECK(nullptr == uv_key_get(&tls_key));
+}
+
+
+TEST_CASE("thread_local_storage_wp", "[thread]") {
+  std::shared_ptr<size_t> sp = std::make_shared<size_t>(42);
+  char name[] = "main";
+  ns_thread threads[2];
+  ASSERT_EQ(0, uv_key_create(&tls_key));
+  ASSERT_NULL(uv_key_get(&tls_key));
+  uv_key_set(&tls_key, name);
+  ASSERT_EQ(name, uv_key_get(&tls_key));
+  ASSERT_EQ(0, threads[0].create(tls_thread, TO_WEAK(sp)));
+  ASSERT_EQ(0, threads[1].create(tls_thread, TO_WEAK(sp)));
+  ASSERT_EQ(0, threads[0].join());
+  ASSERT_EQ(0, threads[1].join());
+  uv_key_delete(&tls_key);
+}
+
+
+static void thread_check_stack(ns_thread*,
+                               std::weak_ptr<uv_thread_options_t> d) {
+  auto arg = d.lock();
+  ASSERT(arg);
+#if defined(__APPLE__)
+  size_t expected;
+  expected = arg == nullptr ? 0 : arg->stack_size;
+  /* 512 kB is the default stack size of threads other than the main thread
+   * on MacOS. */
+  if (expected == 0)
+    expected = 512 * 1024;
+  CHECK(pthread_get_stacksize_np(pthread_self()) >= expected);
+#elif defined(__linux__) && defined(__GLIBC__)
+  size_t expected;
+  struct rlimit lim;
+  size_t stack_size;
+  pthread_attr_t attr;
+  CHECK(0 == getrlimit(RLIMIT_STACK, &lim));
+  if (lim.rlim_cur == RLIM_INFINITY)
+    lim.rlim_cur = 2 << 20;  /* glibc default. */
+  CHECK(0 == pthread_getattr_np(pthread_self(), &attr));
+  CHECK(0 == pthread_attr_getstacksize(&attr, &stack_size));
+  expected = arg == nullptr ? 0 : arg->stack_size;
+  if (expected == 0)
+    expected = (size_t)lim.rlim_cur;
+  CHECK(stack_size >= expected);
+  CHECK(0 == pthread_attr_destroy(&attr));
+#endif
+}
+
+
+TEST_CASE("thread_stack_size_explicit_wp", "[thread]") {
+  std::shared_ptr<uv_thread_options_t> options =
+    std::make_shared<uv_thread_options_t>();
+  std::weak_ptr<uv_thread_options_t> wp = options;
+  ns_thread thread;
+
+  options->flags = UV_THREAD_HAS_STACK_SIZE;
+  options->stack_size = 1024 * 1024;
+  ASSERT_EQ(0, thread.create_ex(options.get(), thread_check_stack, wp));
+  ASSERT_EQ(0, thread.join());
+
+  options->stack_size = 8 * 1024 * 1024;  // larger than most default os sizes
+  ASSERT_EQ(0, thread.create_ex(options.get(), thread_check_stack, wp));
+  ASSERT_EQ(0, thread.join());
+
+  options->stack_size = 0;
+  ASSERT_EQ(0, thread.create_ex(options.get(), thread_check_stack, wp));
+  ASSERT_EQ(0, thread.join());
+
+#ifdef PTHREAD_STACK_MIN
+  options->stack_size = PTHREAD_STACK_MIN - 42;  // unaligned size
+  ASSERT_EQ(0, thread.create_ex(options.get(), thread_check_stack, wp));
+  ASSERT_EQ(0, thread.join());
+
+  options->stack_size = PTHREAD_STACK_MIN / 2 - 42;  // unaligned size
+  ASSERT_EQ(0, thread.create_ex(options.get(), thread_check_stack, wp));
+  ASSERT_EQ(0, thread.join());
+#endif
+
+  // unaligned size, should be larger than PTHREAD_STACK_MIN
+  options->stack_size = 1234567;
+  ASSERT_EQ(0, thread.create_ex(options.get(), thread_check_stack, wp));
+  ASSERT_EQ(0, thread.join());
+}

--- a/test/test-threadpool-wp.cc
+++ b/test/test-threadpool-wp.cc
@@ -1,0 +1,64 @@
+#include "../include/nsuv-inl.h"
+#include "./catch.hpp"
+#include "./helpers.h"
+
+using nsuv::ns_work;
+
+static int work_cb_count;
+static int after_work_cb_count;
+static ns_work work_req;
+
+
+static void work_cb(ns_work* req, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  ASSERT(req == &work_req);
+  work_cb_count++;
+}
+
+static void after_work_cb(ns_work* req, int status, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  ASSERT(status == 0);
+  ASSERT(req == &work_req);
+  after_work_cb_count++;
+}
+
+
+TEST_CASE("threadpool_queue_work_simple_wp", "[threadpool]") {
+  std::shared_ptr<size_t> sp = std::make_shared<size_t>(42);
+  int r;
+
+  work_cb_count = 0;
+  after_work_cb_count = 0;
+
+  r = work_req.queue_work(
+      uv_default_loop(), work_cb, after_work_cb, TO_WEAK(sp));
+  ASSERT(r == 0);
+  uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+
+  ASSERT(work_cb_count == 1);
+  ASSERT(after_work_cb_count == 1);
+
+  make_valgrind_happy();
+}
+
+
+TEST_CASE("threadpool_queue_work_no_after_wp", "[threadpool]") {
+  std::shared_ptr<size_t> sp = std::make_shared<size_t>(42);
+  int r;
+
+  work_cb_count = 0;
+  after_work_cb_count = 0;
+
+  r = work_req.queue_work(uv_default_loop(), work_cb, TO_WEAK(sp));
+  ASSERT(r == 0);
+  uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+
+  ASSERT(work_cb_count == 1);
+  ASSERT(after_work_cb_count == 0);
+
+  make_valgrind_happy();
+}

--- a/test/test-timer-wp.cc
+++ b/test/test-timer-wp.cc
@@ -1,0 +1,304 @@
+#include "../include/nsuv-inl.h"
+#include "./catch.hpp"
+#include "./helpers.h"
+
+using nsuv::ns_timer;
+
+static size_t once_cb_called = 0;
+static size_t once_close_cb_called = 0;
+static size_t repeat_cb_called = 0;
+static size_t repeat_close_cb_called = 0;
+static size_t order_cb_called = 0;
+static uint64_t start_time;
+static uint64_t timer_early_check_expected_time;
+static ns_timer tiny_timer;
+static ns_timer huge_timer1;
+static ns_timer huge_timer2;
+
+
+static void once_close_cb(ns_timer* handle, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+
+  INFO("ONCE_CLOSE_CB");
+
+  ASSERT_NOT_NULL(handle);
+  ASSERT_EQ(0, handle->is_active());
+
+  once_close_cb_called++;
+}
+
+
+static void once_cb(ns_timer* handle, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+
+  INFO("ONCE_CB " << once_cb_called);
+
+  ASSERT_NOT_NULL(handle);
+  ASSERT_EQ(0, handle->is_active());
+
+  once_cb_called++;
+
+  handle->close(once_close_cb, d);
+
+  /* Just call this randomly for the code coverage. */
+  uv_update_time(uv_default_loop());
+}
+
+
+static void repeat_close_cb(ns_timer* handle, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+
+  INFO("REPEAT_CLOSE_CB");
+  ASSERT_NOT_NULL(handle);
+  repeat_close_cb_called++;
+}
+
+
+static void repeat_cb(ns_timer* handle, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+
+  INFO("REPEAT_CB");
+  ASSERT_NOT_NULL(handle);
+  ASSERT_EQ(1, handle->is_active());
+
+  repeat_cb_called++;
+
+  if (repeat_cb_called == 5) {
+    handle->close(repeat_close_cb, d);
+  }
+}
+
+
+static void never_cb(ns_timer*, std::weak_ptr<size_t>) {
+  FAIL("never_cb should never be called");
+}
+
+
+TEST_CASE("timer_wp", "[timer]") {
+  constexpr size_t kTimersSize = 10;
+  std::shared_ptr<size_t> sp = std::make_shared<size_t>(42);
+  ns_timer once_timers[kTimersSize];
+  ns_timer* once;
+  ns_timer repeat;
+  ns_timer never;
+
+  once_cb_called = 0;
+  start_time = uv_now(uv_default_loop());
+  ASSERT_LT(0, start_time);
+
+  /* Let 10 timers time out in 500 ms total. */
+  for (size_t i = 0; i < kTimersSize; i++) {
+    once = &once_timers[i];
+    ASSERT_EQ(0, once->init(uv_default_loop()));
+    ASSERT_EQ(0, once->start(once_cb, i * 50, 0, TO_WEAK(sp)));
+  }
+
+  /* The 11th timer is a repeating timer that runs 4 times */
+  ASSERT_EQ(0, repeat.init(uv_default_loop()));
+  ASSERT_EQ(0, repeat.start(repeat_cb, 100, 100, TO_WEAK(sp)));
+
+  /* The 12th timer should not do anything. */
+  ASSERT_EQ(0, never.init(uv_default_loop()));
+  ASSERT_EQ(0, never.start(never_cb, 100, 100, TO_WEAK(sp)));
+  ASSERT_EQ(0, never.stop());
+  never.unref();
+
+  uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+
+  ASSERT_EQ(once_cb_called, 10);
+  ASSERT_EQ(once_close_cb_called, 10);
+  INFO("repeat_cb_called" << repeat_cb_called);
+  ASSERT_EQ(repeat_cb_called, 5);
+  ASSERT_EQ(repeat_close_cb_called, 1);
+
+  ASSERT_LE(500, uv_now(uv_default_loop()) - start_time);
+
+  make_valgrind_happy();
+}
+
+
+TEST_CASE("timer_start_twice_wp", "[timer]") {
+  std::shared_ptr<size_t> sp = std::make_shared<size_t>(42);
+  ns_timer once;
+  once_cb_called = 0;
+  ASSERT_EQ(0, once.init(uv_default_loop()));
+  ASSERT_EQ(0, once.start(never_cb, 86400 * 1000, 0, TO_WEAK(sp)));
+  ASSERT_EQ(0, once.start(once_cb, 10, 0, TO_WEAK(sp)));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+  ASSERT_EQ(1, once_cb_called);
+
+  make_valgrind_happy();
+}
+
+
+static void order_cb_a(ns_timer*, std::weak_ptr<size_t> d) {
+  auto check = d.lock();
+  ASSERT(check);
+  ASSERT_EQ(order_cb_called++, *check);
+}
+
+
+static void order_cb_b(ns_timer*, std::weak_ptr<size_t> d) {
+  auto check = d.lock();
+  ASSERT(check);
+  ASSERT_EQ(order_cb_called++, *check);
+}
+
+
+TEST_CASE("timer_order_wp", "[timer]") {
+  std::shared_ptr<size_t> sp1 = std::make_shared<size_t>(0);
+  std::shared_ptr<size_t> sp2 = std::make_shared<size_t>(1);
+  std::weak_ptr<size_t> first = sp1;
+  std::weak_ptr<size_t> second = sp2;
+  ns_timer handle_a;
+  ns_timer handle_b;
+
+  ASSERT_EQ(0, handle_a.init(uv_default_loop()));
+  ASSERT_EQ(0, handle_b.init(uv_default_loop()));
+
+  /* Test for starting handle_a then handle_b */
+  ASSERT_EQ(0, handle_a.start(order_cb_a, 0, 0, first));
+  ASSERT_EQ(0, handle_b.start(order_cb_b, 0, 0, second));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+
+  ASSERT_EQ(order_cb_called, 2);
+
+  ASSERT_EQ(0, handle_a.stop());
+  ASSERT_EQ(0, handle_b.stop());
+
+  /* Test for starting handle_b then handle_a */
+  order_cb_called = 0;
+  ASSERT_EQ(0, handle_b.start(order_cb_b, 0, 0, first));
+
+  ASSERT_EQ(0, handle_a.start(order_cb_a, 0, 0, second));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+
+  ASSERT_EQ(order_cb_called, 2);
+
+  make_valgrind_happy();
+}
+
+
+static void tiny_timer_cb(ns_timer* handle, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  ASSERT_EQ(handle, &tiny_timer);
+  tiny_timer.close();
+  huge_timer1.close();
+  huge_timer2.close();
+}
+
+
+TEST_CASE("timer_huge_timeout_wp", "[timer]") {
+  std::shared_ptr<size_t> sp = std::make_shared<size_t>(42);
+  ASSERT_EQ(0, tiny_timer.init(uv_default_loop()));
+  ASSERT_EQ(0, huge_timer1.init(uv_default_loop()));
+  ASSERT_EQ(0, huge_timer2.init(uv_default_loop()));
+  ASSERT_EQ(0, tiny_timer.start(tiny_timer_cb, 1, 0, TO_WEAK(sp)));
+  ASSERT_EQ(0, huge_timer1.start(
+        tiny_timer_cb, 0xffffffffffffLL, 0, TO_WEAK(sp)));
+  ASSERT_EQ(0, huge_timer2.start(
+        tiny_timer_cb, (uint64_t) -1, 0, TO_WEAK(sp)));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+
+  make_valgrind_happy();
+}
+
+
+static void huge_repeat_cb(ns_timer* handle, std::weak_ptr<size_t> d) {
+  static size_t ncalls = 0;
+  auto sp = d.lock();
+
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+
+  if (ncalls == 0)
+    ASSERT_EQ(handle, &huge_timer1);
+  else
+    ASSERT_EQ(handle, &tiny_timer);
+
+  if (++ncalls == 10) {
+    tiny_timer.close();
+    huge_timer1.close();
+  }
+}
+
+
+TEST_CASE("timer_huge_repeat_wp", "[timer]") {
+  std::shared_ptr<size_t> sp = std::make_shared<size_t>(42);
+  ASSERT_EQ(0, tiny_timer.init(uv_default_loop()));
+  ASSERT_EQ(0, huge_timer1.init(uv_default_loop()));
+  ASSERT_EQ(0, tiny_timer.start(huge_repeat_cb, 2, 2, TO_WEAK(sp)));
+  ASSERT_EQ(0, huge_timer1.start(
+        huge_repeat_cb, 1, (uint64_t) -1, TO_WEAK(sp)));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+
+  make_valgrind_happy();
+}
+
+
+static void timer_run_once_timer_cb(ns_timer*, std::weak_ptr<size_t> d) {
+  auto cb_called = d.lock();
+  ASSERT(cb_called);
+  *cb_called += 1;
+}
+
+
+TEST_CASE("timer_run_once_wp", "[timer]") {
+  std::shared_ptr<size_t> sp = std::make_shared<size_t>(0);
+  std::weak_ptr<size_t> cb_called = sp;
+  ns_timer timer_handle;
+
+  ASSERT_EQ(0, timer_handle.init(uv_default_loop()));
+  ASSERT_EQ(0, timer_handle.start(timer_run_once_timer_cb, 0, 0, cb_called));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_ONCE));
+  ASSERT_EQ(1, *sp);
+
+  ASSERT_EQ(0, timer_handle.start(timer_run_once_timer_cb, 1, 0, cb_called));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_ONCE));
+  ASSERT_EQ(2, *sp);
+
+  timer_handle.close();
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_ONCE));
+
+  make_valgrind_happy();
+}
+
+
+static void timer_early_check_cb(ns_timer*, std::weak_ptr<size_t> d) {
+  uint64_t hrtime = uv_hrtime() / 1000000;
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  ASSERT_GE(hrtime, timer_early_check_expected_time);
+}
+
+
+TEST_CASE("timer_early_check_wp", "[timer]") {
+  const uint64_t timeout_ms = 10;
+  std::shared_ptr<size_t> sp = std::make_shared<size_t>(42);
+  ns_timer timer_handle;
+
+  timer_early_check_expected_time = uv_now(uv_default_loop()) + timeout_ms;
+
+  ASSERT_EQ(0, timer_handle.init(uv_default_loop()));
+  ASSERT_EQ(0, timer_handle.start(timer_early_check_cb,
+                                  timeout_ms,
+                                  0,
+                                  TO_WEAK(sp)));
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+
+  timer_handle.close();
+  ASSERT_EQ(0, uv_run(uv_default_loop(), UV_RUN_DEFAULT));
+
+  make_valgrind_happy();
+}

--- a/test/test-udp-multicast-interface-wp.cc
+++ b/test/test-udp-multicast-interface-wp.cc
@@ -1,0 +1,91 @@
+#include "../include/nsuv-inl.h"
+#include "./helpers.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+using nsuv::ns_udp;
+using nsuv::ns_udp_send;
+
+#define CHECK_HANDLE(handle) \
+  ASSERT((reinterpret_cast<ns_udp*>(handle) == &server || \
+        reinterpret_cast<ns_udp*>(handle) == &client))
+
+static ns_udp server;
+static ns_udp client;
+
+static int sv_send_cb_called;
+static int close_cb_called;
+
+static char ping_str[] = "PING";
+
+
+static void close_cb(ns_udp* handle, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  CHECK_HANDLE(handle);
+  close_cb_called++;
+}
+
+
+static void sv_send_cb(ns_udp_send* req, int status, std::weak_ptr<size_t> d) {
+  auto sp = d.lock();
+  ASSERT(sp);
+  ASSERT_EQ(42, *sp);
+  ASSERT_NOT_NULL(req);
+  ASSERT((status == 0 || status == UV_ENETUNREACH || status == UV_EPERM));
+  CHECK_HANDLE(req->handle());
+
+  sv_send_cb_called++;
+
+  req->handle()->close(close_cb, d);
+}
+
+
+TEST_CASE("udp_multicast_interface_wp", "[udp]") {
+/* TODO(gengjiawen): Fix test on QEMU. */
+#if defined(__QEMU__)
+  RETURN_SKIP("Test does not currently work in QEMU");
+#endif
+
+  std::shared_ptr<size_t> sp = std::make_shared<size_t>(42);
+  int r;
+  ns_udp_send req;
+  uv_buf_t buf;
+  struct sockaddr_in addr;
+  struct sockaddr_in baddr;
+
+  ASSERT(0 == uv_ip4_addr("239.255.0.1", kTestPort, &addr));
+
+  r = server.init(uv_default_loop());
+  ASSERT(r == 0);
+
+  ASSERT(0 == uv_ip4_addr("0.0.0.0", 0, &baddr));
+  r = server.bind(SOCKADDR_CONST_CAST(&baddr), 0);
+  ASSERT(r == 0);
+
+  r = uv_udp_set_multicast_interface(&server, "0.0.0.0");
+  ASSERT(r == 0);
+
+  /* server sends "PING" */
+  buf = uv_buf_init(ping_str, 4);
+  r = server.send(
+      &req, &buf, 1, SOCKADDR_CONST_CAST(&addr), sv_send_cb, TO_WEAK(sp));
+  ASSERT(r == 0);
+
+  ASSERT(close_cb_called == 0);
+  ASSERT(sv_send_cb_called == 0);
+
+  /* run the loop till all events are processed */
+  uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+
+  ASSERT(sv_send_cb_called == 1);
+  ASSERT(close_cb_called == 1);
+
+  ASSERT(client.uv_handle()->send_queue_size == 0);
+  ASSERT(server.uv_handle()->send_queue_size == 0);
+
+  make_valgrind_happy();
+}


### PR DESCRIPTION
```
src: add support for weak_ptr

Allow a weak_ptr to be passed to each callback along with a normal
pointer. This will make it easier to not accidentally hold on to
resources when juggling multiple threads.

Many tests were duplicated into test/*-wp.cc just to make sure the
weak_ptr API has test coverage.
```
```
src: point to correct pointer in proxy

The alloc_proxy_() was pointing to the listener cb pointer.
```
```
test: fix comparison bug

Only one side was supposed to be cast. Not the result.
```